### PR TITLE
Use environment variable for ALLOWED_HOSTS configuration

### DIFF
--- a/webcaf/settings.py
+++ b/webcaf/settings.py
@@ -43,7 +43,7 @@ SECRET_KEY: str = str(uuid.uuid4()) if DEBUG else env.str("SECRET_KEY", default=
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS: list = []
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
 
 X_FRAME_OPTIONS = "SAMEORIGIN"
 


### PR DESCRIPTION
- updated the allow host to be the same as other applications as it needs to allow '*' to work with gunicorn in the aws environment.