### PR TITLE
Make indicators dicts in CAF YAML

### DIFF
--- a/frameworks/cyber-assessment-framework-v3.2.yaml
+++ b/frameworks/cyber-assessment-framework-v3.2.yaml
@@ -8,7 +8,6 @@ assessment-rules: &standard-rules
   3:
   - not-achieved
   - any
-
 objectives:
   A:
     code: A
@@ -32,34 +31,43 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A1.a.1: The security of network and information systems related to
-                  the operation of essential function(s) is not discussed or reported
-                  on regularly at board- level.
-                A1.a.2: Board-level discussions on the security of network and information
-                  systems are based on partial or out-of-date information, without
-                  the benefit of expert guidance.
-                A1.a.3: The security of network and information systems supporting
-                  your essential function(s) are not driven effectively by the direction
-                  set at board-level.
-                A1.a.4: Senior management or other pockets of the organisation consider
-                  themselves exempt from some policies or expect special accommodations
-                  to be made.
+                A1.a.1:
+                  description: The security of network and information systems related
+                    to the operation of essential function(s) is not discussed or
+                    reported on regularly at board- level.
+                A1.a.2:
+                  description: Board-level discussions on the security of network
+                    and information systems are based on partial or out-of-date information,
+                    without the benefit of expert guidance.
+                A1.a.3:
+                  description: The security of network and information systems supporting
+                    your essential function(s) are not driven effectively by the direction
+                    set at board-level.
+                A1.a.4:
+                  description: Senior management or other pockets of the organisation
+                    consider themselves exempt from some policies or expect special
+                    accommodations to be made.
               achieved:
-                A1.a.5: Your organisation's approach and policy relating to the security
-                  of network and information systems supporting the operation of your
-                  essential function(s) are owned and managed at board-level. These
-                  are communicated, in a meaningful way, to risk management decision-makers
-                  across the organisation.
-                A1.a.6: Regular board-level discussions on the security of network
-                  and information systems supporting the operation of your essential
-                  function(s) take place, based on timely and accurate information
-                  and informed by expert guidance.
-                A1.a.7: There is a board-level individual who has overall accountability
-                  for the security of network and information systems and drives regular
-                  discussion at board-level.
-                A1.a.8: Direction set at board-level is translated into effective
-                  organisational practices that direct and control the security of
-                  the network and information systems supporting your essential function(s).
+                A1.a.5:
+                  description: Your organisation's approach and policy relating to
+                    the security of network and information systems supporting the
+                    operation of your essential function(s) are owned and managed
+                    at board-level. These are communicated, in a meaningful way, to
+                    risk management decision-makers across the organisation.
+                A1.a.6:
+                  description: Regular board-level discussions on the security of
+                    network and information systems supporting the operation of your
+                    essential function(s) take place, based on timely and accurate
+                    information and informed by expert guidance.
+                A1.a.7:
+                  description: There is a board-level individual who has overall accountability
+                    for the security of network and information systems and drives
+                    regular discussion at board-level.
+                A1.a.8:
+                  description: Direction set at board-level is translated into effective
+                    organisational practices that direct and control the security
+                    of the network and information systems supporting your essential
+                    function(s).
             assessment-rules: *standard-rules
           A1.b:
             code: A1.b
@@ -71,23 +79,29 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A1.b.1: Key roles are missing, left vacant, or fulfilled on an ad-hoc
-                  or informal basis.
-                A1.b.2: Staff are assigned security responsibilities but without adequate
-                  authority or resources to fulfil them.
-                A1.b.3: Staff are unsure what their responsibilities are for the security
-                  of the essential function(s).
+                A1.b.1:
+                  description: Key roles are missing, left vacant, or fulfilled on
+                    an ad-hoc or informal basis.
+                A1.b.2:
+                  description: Staff are assigned security responsibilities but without
+                    adequate authority or resources to fulfil them.
+                A1.b.3:
+                  description: Staff are unsure what their responsibilities are for
+                    the security of the essential function(s).
               achieved:
-                A1.b.4: Key roles and responsibilities for the security of network
-                  and information systems supporting your essential function(s) have
-                  been identified. These are reviewed regularly to ensure they remain
-                  fit for purpose.
-                A1.b.5: Appropriately capable and knowledgeable staff fill those roles
-                  and are given the time, authority, and resources to carry out their
-                  duties.
-                A1.b.6: There is clarity on who in your organisation has overall accountability
-                  for the security of the network and information systems supporting
-                  your essential function(s).
+                A1.b.4:
+                  description: Key roles and responsibilities for the security of
+                    network and information systems supporting your essential function(s)
+                    have been identified. These are reviewed regularly to ensure they
+                    remain fit for purpose.
+                A1.b.5:
+                  description: Appropriately capable and knowledgeable staff fill
+                    those roles and are given the time, authority, and resources to
+                    carry out their duties.
+                A1.b.6:
+                  description: There is clarity on who in your organisation has overall
+                    accountability for the security of the network and information
+                    systems supporting your essential function(s).
             assessment-rules: *standard-rules
           A1.c:
             code: A1.c
@@ -100,31 +114,40 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A1.c.1: What should be relatively straightforward risk decisions are
-                  constantly referred up the chain, or not made.
-                A1.c.2: Risks are resolved informally (or ignored) at a local level
-                  when the use of a more formal risk reporting mechanism would be
-                  more appropriate.
-                A1.c.3: Decision-makers are unsure of what senior management's risk
-                  appetite is, or only understand it in vague terms such as "averse"
-                  or "cautious".
-                A1.c.4: Organisational structure causes risk decisions to be made
-                  in isolation. (e.g. engineering and IT don't talk to each other
-                  about risk).
-                A1.c.5: Risk priorities are too vague to make meaningful distinctions
-                  between them. (e.g. almost all risks are rated 'medium' or 'amber').
+                A1.c.1:
+                  description: What should be relatively straightforward risk decisions
+                    are constantly referred up the chain, or not made.
+                A1.c.2:
+                  description: Risks are resolved informally (or ignored) at a local
+                    level when the use of a more formal risk reporting mechanism would
+                    be more appropriate.
+                A1.c.3:
+                  description: Decision-makers are unsure of what senior management's
+                    risk appetite is, or only understand it in vague terms such as
+                    "averse" or "cautious".
+                A1.c.4:
+                  description: Organisational structure causes risk decisions to be
+                    made in isolation. (e.g. engineering and IT don't talk to each
+                    other about risk).
+                A1.c.5:
+                  description: Risk priorities are too vague to make meaningful distinctions
+                    between them. (e.g. almost all risks are rated 'medium' or 'amber').
               achieved:
-                A1.c.6: Senior management have visibility of key risk decisions made
-                  throughout the organisation.
-                A1.c.7: Risk management decision-makers understand their responsibilities
-                  for making effective and timely decisions in the context of the
-                  risk appetite regarding the essential function(s), as set by senior
-                  management.
-                A1.c.8: Risk management decision-making is delegated and escalated
-                  where necessary, across the organisation, to people who have the
-                  skills, knowledge, tools and authority they need.
-                A1.c.9: Risk management decisions are regularly reviewed to ensure
-                  their continued relevance and validity.
+                A1.c.6:
+                  description: Senior management have visibility of key risk decisions
+                    made throughout the organisation.
+                A1.c.7:
+                  description: Risk management decision-makers understand their responsibilities
+                    for making effective and timely decisions in the context of the
+                    risk appetite regarding the essential function(s), as set by senior
+                    management.
+                A1.c.8:
+                  description: Risk management decision-making is delegated and escalated
+                    where necessary, across the organisation, to people who have the
+                    skills, knowledge, tools and authority they need.
+                A1.c.9:
+                  description: Risk management decisions are regularly reviewed to
+                    ensure their continued relevance and validity.
             assessment-rules: *standard-rules
       A2:
         code: A2
@@ -143,59 +166,76 @@ objectives:
               activities.
             indicators:
               not-achieved:
-                A2.a.1: Risk assessments are not based on a clearly defined set of
-                  threat assumptions.
-                A2.a.2: Risk assessment outputs are too complex or unwieldy to be
-                  consumed by decision-makers and are not effectively communicated
-                  in a clear and timely manner.
-                A2.a.3: Risk assessments for network and information systems supporting
-                  your essential function(s) are a "one-off" activity or not done
-                  at all.
-                A2.a.4: The security elements of projects or programmes are solely
-                  dependent on the completion of a risk management assessment without
-                  any regard to the outcomes.
-                A2.a.5: There is no systematic process in place to ensure that identified
-                  security risks are managed effectively.
-                A2.a.6: Systems are assessed in isolation, without consideration of
-                  dependencies and interactions with other systems. (e.g. interactions
-                  between IT and OT environments).
-                A2.a.7: Security requirements and mitigations are arbitrary or are
-                  applied from a control catalogue without consideration of how they
-                  contribute to the security of the essential function(s).
+                A2.a.1:
+                  description: Risk assessments are not based on a clearly defined
+                    set of threat assumptions.
+                A2.a.2:
+                  description: Risk assessment outputs are too complex or unwieldy
+                    to be consumed by decision-makers and are not effectively communicated
+                    in a clear and timely manner.
+                A2.a.3:
+                  description: Risk assessments for network and information systems
+                    supporting your essential function(s) are a "one-off" activity
+                    or not done at all.
+                A2.a.4:
+                  description: The security elements of projects or programmes are
+                    solely dependent on the completion of a risk management assessment
+                    without any regard to the outcomes.
+                A2.a.5:
+                  description: There is no systematic process in place to ensure that
+                    identified security risks are managed effectively.
+                A2.a.6:
+                  description: Systems are assessed in isolation, without consideration
+                    of dependencies and interactions with other systems. (e.g. interactions
+                    between IT and OT environments).
+                A2.a.7:
+                  description: Security requirements and mitigations are arbitrary
+                    or are applied from a control catalogue without consideration
+                    of how they contribute to the security of the essential function(s).
               partially-achieved:
-                A2.a.8: Your organisational process ensures that security risks to
-                  network and information systems relevant to essential function(s)
-                  are identified, analysed, prioritised, and managed.
-                A2.a.9: Your risk assessments are informed by an understanding of
-                  the vulnerabilities in the network and information systems supporting
-                  your essential function(s).
-                A2.a.10: The output from your risk management process is a clear set
-                  of security requirements that will address the risks in line with
-                  your organisational approach to security.
-                A2.a.11: Significant conclusions reached in the course of your risk
-                  management process are communicated to key security decision-makers
-                  and accountable individuals.
-                A2.a.12: You conduct risk assessments when significant events potentially
-                  affect the essential function(s), such as replacing a system or
-                  a change in the cyber security threat.
+                A2.a.8:
+                  description: Your organisational process ensures that security risks
+                    to network and information systems relevant to essential function(s)
+                    are identified, analysed, prioritised, and managed.
+                A2.a.9:
+                  description: Your risk assessments are informed by an understanding
+                    of the vulnerabilities in the network and information systems
+                    supporting your essential function(s).
+                A2.a.10:
+                  description: The output from your risk management process is a clear
+                    set of security requirements that will address the risks in line
+                    with your organisational approach to security.
+                A2.a.11:
+                  description: Significant conclusions reached in the course of your
+                    risk management process are communicated to key security decision-makers
+                    and accountable individuals.
+                A2.a.12:
+                  description: You conduct risk assessments when significant events
+                    potentially affect the essential function(s), such as replacing
+                    a system or a change in the cyber security threat.
               achieved:
-                A2.a.13: Your organisational process ensures that security risks to
-                  network and information systems relevant to essential function(s)
-                  are identified, analysed, prioritised, and managed.
-                A2.a.14: Your approach to risk is focused on the possibility of adverse
-                  impact to your essential function(s), leading to a detailed understanding
-                  of how such impact might arise as a consequence of possible attacker
-                  actions and the security properties of your network and information
-                  systems.
-                A2.a.15: Your risk assessments are based on a clearly understood set
-                  of threat assumptions, informed by an up-to-date understanding of
-                  security threats to your essential function(s) and your sector.
-                A2.a.16: Your risk assessments are informed by an understanding of
-                  the vulnerabilities in the network and information systems supporting
-                  your essential function(s).
-                A2.a.17: The output from your risk management process is a clear set
-                  of security requirements that will address the risks in line with
-                  your organisational approach to security.
+                A2.a.13:
+                  description: Your organisational process ensures that security risks
+                    to network and information systems relevant to essential function(s)
+                    are identified, analysed, prioritised, and managed.
+                A2.a.14:
+                  description: Your approach to risk is focused on the possibility
+                    of adverse impact to your essential function(s), leading to a
+                    detailed understanding of how such impact might arise as a consequence
+                    of possible attacker actions and the security properties of your
+                    network and information systems.
+                A2.a.15:
+                  description: Your risk assessments are based on a clearly understood
+                    set of threat assumptions, informed by an up-to-date understanding
+                    of security threats to your essential function(s) and your sector.
+                A2.a.16:
+                  description: Your risk assessments are informed by an understanding
+                    of the vulnerabilities in the network and information systems
+                    supporting your essential function(s).
+                A2.a.17:
+                  description: The output from your risk management process is a clear
+                    set of security requirements that will address the risks in line
+                    with your organisational approach to security.
             assessment-rules: *standard-rules
           A2.b:
             code: A2.b
@@ -206,29 +246,37 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A2.b.1: A particular product or service is seen as a "silver bullet"
-                  and vendor claims are taken at face value.
-                A2.b.2: Assurance methods are applied without appreciation of their
-                  strengths and limitations, such as the risks of penetration testing
-                  in operational environments.
-                A2.b.3: Assurance is assumed because there have been no known problems
-                  to date.
+                A2.b.1:
+                  description: A particular product or service is seen as a "silver
+                    bullet" and vendor claims are taken at face value.
+                A2.b.2:
+                  description: Assurance methods are applied without appreciation
+                    of their strengths and limitations, such as the risks of penetration
+                    testing in operational environments.
+                A2.b.3:
+                  description: Assurance is assumed because there have been no known
+                    problems to date.
               achieved:
-                A2.b.4: You validate that the security measures in place to protect
-                  the network and information systems are effective and remain effective
-                  for the lifetime over which they are needed.
-                A2.b.5: You understand the assurance methods available to you and
-                  choose appropriate methods to gain confidence in the security of
-                  essential function(s).
-                A2.b.6: Your confidence in the security as it relates to your technology,
-                  people, and processes can be justified to, and verified by, a third
-                  party.
-                A2.b.7: Security deficiencies uncovered by assurance activities are
-                  assessed, prioritised and remedied when necessary in a timely and
-                  effective way.
-                A2.b.8: The methods used for assurance are reviewed to ensure they
-                  are working as intended and remain the most appropriate method to
-                  use.
+                A2.b.4:
+                  description: You validate that the security measures in place to
+                    protect the network and information systems are effective and
+                    remain effective for the lifetime over which they are needed.
+                A2.b.5:
+                  description: You understand the assurance methods available to you
+                    and choose appropriate methods to gain confidence in the security
+                    of essential function(s).
+                A2.b.6:
+                  description: Your confidence in the security as it relates to your
+                    technology, people, and processes can be justified to, and verified
+                    by, a third party.
+                A2.b.7:
+                  description: Security deficiencies uncovered by assurance activities
+                    are assessed, prioritised and remedied when necessary in a timely
+                    and effective way.
+                A2.b.8:
+                  description: The methods used for assurance are reviewed to ensure
+                    they are working as intended and remain the most appropriate method
+                    to use.
             assessment-rules: *standard-rules
       A3:
         code: A3
@@ -245,31 +293,41 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A3.a.1: Inventories of assets relevant to the essential function(s)
-                  are incomplete, non-existent, or inadequately detailed.
-                A3.a.2: Only certain domains or types of asset are documented and
-                  understood. Dependencies between assets are not understood (such
-                  as the dependencies between IT and OT).
-                A3.a.3: Information assets, which could include personally identifiable
-                  information and / or important / critical data, are stored for long
-                  periods of time with no clear business need or retention policy.
-                A3.a.4: Knowledge critical to the management, operation, or recovery
-                  of the essential function(s) is held by one or two key individuals
-                  with no succession plan.
+                A3.a.1:
+                  description: Inventories of assets relevant to the essential function(s)
+                    are incomplete, non-existent, or inadequately detailed.
+                A3.a.2:
+                  description: Only certain domains or types of asset are documented
+                    and understood. Dependencies between assets are not understood
+                    (such as the dependencies between IT and OT).
+                A3.a.3:
+                  description: Information assets, which could include personally
+                    identifiable information and / or important / critical data, are
+                    stored for long periods of time with no clear business need or
+                    retention policy.
+                A3.a.4:
+                  description: Knowledge critical to the management, operation, or
+                    recovery of the essential function(s) is held by one or two key
+                    individuals with no succession plan.
               achieved:
-                A3.a.5: All assets relevant to the secure operation of essential function(s)
-                  are identified and inventoried (at a suitable level of detail).
-                  The inventory is kept up-to-date.
-                A3.a.6: Dependencies on supporting infrastructure (e.g. power, cooling
-                  etc) are recognised and recorded.
-                A3.a.7: You have prioritised your assets according to their importance
-                  to the operation of the essential function(s).
-                A3.a.8: You have assigned responsibility for managing all assets,
-                  including physical assets, relevant to the operation of the essential
-                  function(s).
-                A3.a.9: Assets relevant to the essential function(s) are managed with
-                  cyber security in mind throughout their lifecycle, from creation
-                  through to eventual decommissioning or disposal.
+                A3.a.5:
+                  description: All assets relevant to the secure operation of essential
+                    function(s) are identified and inventoried (at a suitable level
+                    of detail). The inventory is kept up-to-date.
+                A3.a.6:
+                  description: Dependencies on supporting infrastructure (e.g. power,
+                    cooling etc) are recognised and recorded.
+                A3.a.7:
+                  description: You have prioritised your assets according to their
+                    importance to the operation of the essential function(s).
+                A3.a.8:
+                  description: You have assigned responsibility for managing all assets,
+                    including physical assets, relevant to the operation of the essential
+                    function(s).
+                A3.a.9:
+                  description: Assets relevant to the essential function(s) are managed
+                    with cyber security in mind throughout their lifecycle, from creation
+                    through to eventual decommissioning or disposal.
             assessment-rules: *standard-rules
       A4:
         code: A4
@@ -286,52 +344,70 @@ objectives:
             description: ''
             indicators:
               not-achieved:
-                A4.a.1: You do not know what data belonging to you is held by suppliers,
-                  or how it is managed.
-                A4.a.2: Elements of the supply chain for essential function(s) are
-                  subcontracted and you little or no visibility of the sub-contractors.
-                A4.a.3: You have no understanding of which contracts are relevant
-                  and / or relevant contracts do not specify appropriate security
-                  obligations.
-                A4.a.4: Suppliers have access to systems that provide your essential
-                  function(s) that is unrestricted, not monitored or bypasses your
-                  own security controls.
+                A4.a.1:
+                  description: You do not know what data belonging to you is held
+                    by suppliers, or how it is managed.
+                A4.a.2:
+                  description: Elements of the supply chain for essential function(s)
+                    are subcontracted and you little or no visibility of the sub-contractors.
+                A4.a.3:
+                  description: You have no understanding of which contracts are relevant
+                    and / or relevant contracts do not specify appropriate security
+                    obligations.
+                A4.a.4:
+                  description: Suppliers have access to systems that provide your
+                    essential function(s) that is unrestricted, not monitored or bypasses
+                    your own security controls.
               partially-achieved:
-                A4.a.5: You understand the general risks suppliers may pose to your
-                  essential function(s).
-                A4.a.6: You know the extent of your supply chain that supports your
-                  essential function(s), including sub-contractors.
-                A4.a.7: You understand which contracts are relevant and you include
-                  appropriate security obligations in relevant contracts.
-                A4.a.8: You are aware of all third-party connections and have assurance
-                  that they meet your organisation's security requirements.
-                A4.a.9: Your approach to security incident management considers incidents
-                  that might arise in your supply chain.
-                A4.a.10: You have confidence that information shared with suppliers
-                  that is necessary for the operation of your essential function(s)
-                  is appropriately protected from well-known attacks and known vulnerabilities.
+                A4.a.5:
+                  description: You understand the general risks suppliers may pose
+                    to your essential function(s).
+                A4.a.6:
+                  description: You know the extent of your supply chain that supports
+                    your essential function(s), including sub-contractors.
+                A4.a.7:
+                  description: You understand which contracts are relevant and you
+                    include appropriate security obligations in relevant contracts.
+                A4.a.8:
+                  description: You are aware of all third-party connections and have
+                    assurance that they meet your organisation's security requirements.
+                A4.a.9:
+                  description: Your approach to security incident management considers
+                    incidents that might arise in your supply chain.
+                A4.a.10:
+                  description: You have confidence that information shared with suppliers
+                    that is necessary for the operation of your essential function(s)
+                    is appropriately protected from well-known attacks and known vulnerabilities.
               achieved:
-                A4.a.11: You have a deep understanding of your supply chain, including
-                  sub- contractors and the wider risks it faces. You consider factors
-                  such as supplier's partnerships, competitors, nationality and other
-                  organisations with which they sub- contract. This informs your risk
-                  assessment and procurement processes.
-                A4.a.12: Your approach to supply chain risk management considers the
-                  risks to your essential function(s) arising from supply chain subversion
-                  by capable and well-resourced attackers.
-                A4.a.13: You have confidence that information shared with suppliers
-                  that is essential to the operation of your function(s) is appropriately
-                  protected from sophisticated attacks.
-                A4.a.14: You understand which contracts are relevant and you include
-                  appropriate security obligations in relevant contracts. You have
-                  a proactive approach to contract management which may include a
-                  contract management.
-                A4.a.15: Customer / supplier ownership of responsibilities is laid
-                  out in contracts.
-                A4.a.16: All network connections and data sharing with third parties
-                  are managed effectively and proportionately.
-                A4.a.17: When appropriate, your incident management process and that
-                  of your suppliers provide mutual support in the resolution of incidents.
+                A4.a.11:
+                  description: You have a deep understanding of your supply chain,
+                    including sub- contractors and the wider risks it faces. You consider
+                    factors such as supplier's partnerships, competitors, nationality
+                    and other organisations with which they sub- contract. This informs
+                    your risk assessment and procurement processes.
+                A4.a.12:
+                  description: Your approach to supply chain risk management considers
+                    the risks to your essential function(s) arising from supply chain
+                    subversion by capable and well-resourced attackers.
+                A4.a.13:
+                  description: You have confidence that information shared with suppliers
+                    that is essential to the operation of your function(s) is appropriately
+                    protected from sophisticated attacks.
+                A4.a.14:
+                  description: You understand which contracts are relevant and you
+                    include appropriate security obligations in relevant contracts.
+                    You have a proactive approach to contract management which may
+                    include a contract management.
+                A4.a.15:
+                  description: Customer / supplier ownership of responsibilities is
+                    laid out in contracts.
+                A4.a.16:
+                  description: All network connections and data sharing with third
+                    parties are managed effectively and proportionately.
+                A4.a.17:
+                  description: When appropriate, your incident management process
+                    and that of your suppliers provide mutual support in the resolution
+                    of incidents.
             assessment-rules: *standard-rules
   B:
     code: B
@@ -354,45 +430,62 @@ objectives:
               and mitigate the risk of adverse impact on your essential function(s).
             indicators:
               not-achieved:
-                B1.a.1: Your policies, processes and procedures are absent or incomplete.
-                B1.a.2: Policies, processes and procedures are not applied universally
-                  or consistently.
-                B1.a.3: People often or routinely circumvent policies, processes and
-                  procedures to achieve business objectives.
-                B1.a.4: Your organisation's security governance and risk management
-                  approach has no bearing on your policies, processes and procedures.
-                B1.a.5: System security is totally reliant on users' careful and consistent
-                  application of manual security processes.
-                B1.a.6: Policies, processes and procedures have not been reviewed
-                  in response to major changes (e.g. technology or regulatory framework),
-                  or within a suitable period.
-                B1.a.7: Policies, processes and procedures are not readily available
-                  to staff, too detailed to remember, or too hard to understand.
+                B1.a.1:
+                  description: Your policies, processes and procedures are absent
+                    or incomplete.
+                B1.a.2:
+                  description: Policies, processes and procedures are not applied
+                    universally or consistently.
+                B1.a.3:
+                  description: People often or routinely circumvent policies, processes
+                    and procedures to achieve business objectives.
+                B1.a.4:
+                  description: Your organisation's security governance and risk management
+                    approach has no bearing on your policies, processes and procedures.
+                B1.a.5:
+                  description: System security is totally reliant on users' careful
+                    and consistent application of manual security processes.
+                B1.a.6:
+                  description: Policies, processes and procedures have not been reviewed
+                    in response to major changes (e.g. technology or regulatory framework),
+                    or within a suitable period.
+                B1.a.7:
+                  description: Policies, processes and procedures are not readily
+                    available to staff, too detailed to remember, or too hard to understand.
               partially-achieved:
-                B1.a.8: Your policies, processes and procedures document your overarching
-                  security governance and risk management approach, technical security
-                  practice and specific regulatory compliance.
-                B1.a.9: You review and update policies, processes and procedures in
-                  response to major cyber security incidents.
+                B1.a.8:
+                  description: Your policies, processes and procedures document your
+                    overarching security governance and risk management approach,
+                    technical security practice and specific regulatory compliance.
+                B1.a.9:
+                  description: You review and update policies, processes and procedures
+                    in response to major cyber security incidents.
               achieved:
-                B1.a.10: You fully document your overarching security governance and
-                  risk management approach, technical security practice and specific
-                  regulatory compliance. Cyber security is integrated and embedded
-                  throughout policies, processes and procedures and key performance
-                  indicators are reported to your executive management.
-                B1.a.11: Your organisation's policies, processes and procedures are
-                  developed to be practical, usable and appropriate for your essential
-                  function(s) and your technologies.
-                B1.a.12: Policies, processes and procedures that rely on user behaviour
-                  are practical, appropriate and achievable.
-                B1.a.13: You review and update policies, processes and procedures
-                  at suitably regular intervals to ensure they remain relevant. This
-                  is in addition to reviews following a major cyber security incident.
-                B1.a.14: Any changes to the essential function(s) or the threat it
-                  faces triggers a review of policies, processes and procedures.
-                B1.a.15: Your systems are designed so that they remain secure even
-                  when user security policies, processes and procedures are not always
-                  followed.
+                B1.a.10:
+                  description: You fully document your overarching security governance
+                    and risk management approach, technical security practice and
+                    specific regulatory compliance. Cyber security is integrated and
+                    embedded throughout policies, processes and procedures and key
+                    performance indicators are reported to your executive management.
+                B1.a.11:
+                  description: Your organisation's policies, processes and procedures
+                    are developed to be practical, usable and appropriate for your
+                    essential function(s) and your technologies.
+                B1.a.12:
+                  description: Policies, processes and procedures that rely on user
+                    behaviour are practical, appropriate and achievable.
+                B1.a.13:
+                  description: You review and update policies, processes and procedures
+                    at suitably regular intervals to ensure they remain relevant.
+                    This is in addition to reviews following a major cyber security
+                    incident.
+                B1.a.14:
+                  description: Any changes to the essential function(s) or the threat
+                    it faces triggers a review of policies, processes and procedures.
+                B1.a.15:
+                  description: Your systems are designed so that they remain secure
+                    even when user security policies, processes and procedures are
+                    not always followed.
             assessment-rules: *standard-rules
           B1.b:
             code: B1.b
@@ -401,42 +494,56 @@ objectives:
               processes and procedures and can demonstrate the security benefits achieved.
             indicators:
               not-achieved:
-                B1.b.1: Policies, processes and procedures are ignored or only partially
-                  followed.
-                B1.b.2: How your policies, processes and procedures support the resilience
-                  of your essential function(s) is not well understood.
-                B1.b.3: Staff are unaware of their responsibilities under your policies,
-                  processes and procedures.
-                B1.b.4: You do not attempt to detect breaches of policies, processes
-                  and procedures.
-                B1.b.5: Policies, processes and procedures lack integration with other
-                  organisational policies, processes and procedures.
-                B1.b.6: Your policies, processes and procedures are not well communicated
-                  across your organisation.
+                B1.b.1:
+                  description: Policies, processes and procedures are ignored or only
+                    partially followed.
+                B1.b.2:
+                  description: How your policies, processes and procedures support
+                    the resilience of your essential function(s) is not well understood.
+                B1.b.3:
+                  description: Staff are unaware of their responsibilities under your
+                    policies, processes and procedures.
+                B1.b.4:
+                  description: You do not attempt to detect breaches of policies,
+                    processes and procedures.
+                B1.b.5:
+                  description: Policies, processes and procedures lack integration
+                    with other organisational policies, processes and procedures.
+                B1.b.6:
+                  description: Your policies, processes and procedures are not well
+                    communicated across your organisation.
               partially-achieved:
-                B1.b.7: Most of your policies, processes and procedures are followed
-                  and their application is monitored.
-                B1.b.8: Your policies, processes and procedures are integrated with
-                  other organisational policies, processes and procedures, including
-                  HR assessments of individuals' trustworthiness.
-                B1.b.9: All staff are aware of their responsibilities under your policies,
-                  processes and procedures.
-                B1.b.10: All breaches of policies, processes and procedures with the
-                  potential to adversely impact the essential function(s) are fully
-                  investigated. Other breaches are tracked, assessed for trends and
-                  action is taken to understand and address.
+                B1.b.7:
+                  description: Most of your policies, processes and procedures are
+                    followed and their application is monitored.
+                B1.b.8:
+                  description: Your policies, processes and procedures are integrated
+                    with other organisational policies, processes and procedures,
+                    including HR assessments of individuals' trustworthiness.
+                B1.b.9:
+                  description: All staff are aware of their responsibilities under
+                    your policies, processes and procedures.
+                B1.b.10:
+                  description: All breaches of policies, processes and procedures
+                    with the potential to adversely impact the essential function(s)
+                    are fully investigated. Other breaches are tracked, assessed for
+                    trends and action is taken to understand and address.
               achieved:
-                B1.b.11: All your policies, processes and procedures are followed,
-                  their correct application and security effectiveness is evaluated.
-                B1.b.12: Your policies, processes and procedures are integrated with
-                  other organisational policies, processes and procedures, including
-                  HR assessments of individuals' trustworthiness.
-                B1.b.13: Your policies, processes and procedures are effectively and
-                  appropriately communicated across all levels of the organisation
-                  resulting in good staff awareness of their responsibilities.
-                B1.b.14: Appropriate action is taken to address all breaches of policies,
-                  processes and procedures with potential to adversely impact the
-                  essential function(s) including aggregated breaches.
+                B1.b.11:
+                  description: All your policies, processes and procedures are followed,
+                    their correct application and security effectiveness is evaluated.
+                B1.b.12:
+                  description: Your policies, processes and procedures are integrated
+                    with other organisational policies, processes and procedures,
+                    including HR assessments of individuals' trustworthiness.
+                B1.b.13:
+                  description: Your policies, processes and procedures are effectively
+                    and appropriately communicated across all levels of the organisation
+                    resulting in good staff awareness of their responsibilities.
+                B1.b.14:
+                  description: Appropriate action is taken to address all breaches
+                    of policies, processes and procedures with potential to adversely
+                    impact the essential function(s) including aggregated breaches.
             assessment-rules: *standard-rules
       B2:
         code: B2
@@ -453,59 +560,81 @@ objectives:
               the network and information systems supporting your essential function(s).
             indicators:
               not-achieved:
-                B2.a.1: Initial identity verification is not robust enough to provide
-                  an acceptable level of confidence of a user's identity profile.
-                B2.a.2: Authorised users and systems with access to networks or information
-                  systems on which your essential function(s) depends cannot be individually
-                  identified.
-                B2.a.3: Unauthorised individuals or devices can access your network
-                  or information systems on which your essential function(s) depends.
-                B2.a.4: The number of authorised users and systems that have access
-                  to your network and information systems are not limited to the minimum
-                  necessary.
-                B2.a.5: Your approach to authenticating users, devices and systems
-                  does not follow up to date best practice.
+                B2.a.1:
+                  description: Initial identity verification is not robust enough
+                    to provide an acceptable level of confidence of a user's identity
+                    profile.
+                B2.a.2:
+                  description: Authorised users and systems with access to networks
+                    or information systems on which your essential function(s) depends
+                    cannot be individually identified.
+                B2.a.3:
+                  description: Unauthorised individuals or devices can access your
+                    network or information systems on which your essential function(s)
+                    depends.
+                B2.a.4:
+                  description: The number of authorised users and systems that have
+                    access to your network and information systems are not limited
+                    to the minimum necessary.
+                B2.a.5:
+                  description: Your approach to authenticating users, devices and
+                    systems does not follow up to date best practice.
               partially-achieved:
-                B2.a.6: Your process of initial identity verification is robust enough
-                  to provide a reasonable level of confidence of a user's identity
-                  profile before allowing an authorised user access to network and
-                  information systems that support your essential function(s).
-                B2.a.7: All authorised users and systems with access to network or
-                  information systems on which your essential function(s) depends
-                  are individually identified and authenticated.
-                B2.a.8: The number of authorised users and systems that have access
-                  to essential function(s) network and information systems is limited
-                  to the minimum necessary.
-                B2.a.9: You use additional authentication mechanisms, such as multi-factor
-                  (MFA), for privileged access to all network and information systems
-                  that operate or support your essential function(s).
-                B2.a.10: You individually authenticate and authorise all remote access
-                  to all your network and information systems that support your essential
-                  function(s).
-                B2.a.11: The list of users and systems with access to network and
-                  information systems supporting and delivering the essential function(s)
-                  is reviewed on a regular basis, at least annually.
-                B2.a.12: Your approach to authenticating users, devices and systems
-                  follows up to date best practice.
+                B2.a.6:
+                  description: Your process of initial identity verification is robust
+                    enough to provide a reasonable level of confidence of a user's
+                    identity profile before allowing an authorised user access to
+                    network and information systems that support your essential function(s).
+                B2.a.7:
+                  description: All authorised users and systems with access to network
+                    or information systems on which your essential function(s) depends
+                    are individually identified and authenticated.
+                B2.a.8:
+                  description: The number of authorised users and systems that have
+                    access to essential function(s) network and information systems
+                    is limited to the minimum necessary.
+                B2.a.9:
+                  description: You use additional authentication mechanisms, such
+                    as multi-factor (MFA), for privileged access to all network and
+                    information systems that operate or support your essential function(s).
+                B2.a.10:
+                  description: You individually authenticate and authorise all remote
+                    access to all your network and information systems that support
+                    your essential function(s).
+                B2.a.11:
+                  description: The list of users and systems with access to network
+                    and information systems supporting and delivering the essential
+                    function(s) is reviewed on a regular basis, at least annually.
+                B2.a.12:
+                  description: Your approach to authenticating users, devices and
+                    systems follows up to date best practice.
               achieved:
-                B2.a.13: Your process of initial identity verification is robust enough
-                  to provide a high level of confidence of a user's identity profile
-                  before allowing an authorised user access to network and information
-                  systems that support your essential function(s).
-                B2.a.14: Only authorised and individually authenticated users can
-                  physically access and logically connect to your network or information
-                  systems on which your essential function(s) depends.
-                B2.a.15: The number of authorised users and systems that have access
-                  to all your network and information systems supporting the essential
-                  function(s) is limited to the minimum necessary.
-                B2.a.16: You use additional authentication mechanisms, such as multi-factor
-                  (MFA), for all user access, including remote access, to all network
-                  and information systems that operate or support your essential function(s).
-                B2.a.17: The list of users and systems with access to network and
-                  information systems supporting and delivering the essential function(s)
-                  is reviewed on a regular basis, at least every six months.
-                B2.a.18: Your approach to authenticating users, devices and systems
-                  follows up to date best practice.
+                B2.a.13:
+                  description: Your process of initial identity verification is robust
+                    enough to provide a high level of confidence of a user's identity
+                    profile before allowing an authorised user access to network and
+                    information systems that support your essential function(s).
+                B2.a.14:
+                  description: Only authorised and individually authenticated users
+                    can physically access and logically connect to your network or
+                    information systems on which your essential function(s) depends.
+                B2.a.15:
+                  description: The number of authorised users and systems that have
+                    access to all your network and information systems supporting
+                    the essential function(s) is limited to the minimum necessary.
+                B2.a.16:
+                  description: You use additional authentication mechanisms, such
+                    as multi-factor (MFA), for all user access, including remote access,
+                    to all network and information systems that operate or support
+                    your essential function(s).
+                B2.a.17:
+                  description: The list of users and systems with access to network
+                    and information systems supporting and delivering the essential
+                    function(s) is reviewed on a regular basis, at least every six
+                    months.
+                B2.a.18:
+                  description: Your approach to authenticating users, devices and
+                    systems follows up to date best practice.
             assessment-rules: *standard-rules
           B2.b:
             code: B2.b
@@ -515,44 +644,58 @@ objectives:
               essential function(s).
             indicators:
               not-achieved:
-                B2.b.1: Users can connect to your network and information systems
-                  supporting your essential function(s) using devices that are not
-                  corporately owned and managed.
-                B2.b.2: Privileged users can perform privileged operations from devices
-                  that are not corporately owned and managed.
-                B2.b.3: You have not gained assurance in the security of any third-party
-                  devices or networks connected to your systems.
-                B2.b.4: Physically connecting a device to your network and information
-                  systems gives that device access without device or user authentication.
+                B2.b.1:
+                  description: Users can connect to your network and information systems
+                    supporting your essential function(s) using devices that are not
+                    corporately owned and managed.
+                B2.b.2:
+                  description: Privileged users can perform privileged operations
+                    from devices that are not corporately owned and managed.
+                B2.b.3:
+                  description: You have not gained assurance in the security of any
+                    third-party devices or networks connected to your systems.
+                B2.b.4:
+                  description: Physically connecting a device to your network and
+                    information systems gives that device access without device or
+                    user authentication.
               partially-achieved:
-                B2.b.5: Only corporately owned and managed devices can access your
-                  essential function(s) network and information systems.
-                B2.b.6: All privileged operations are performed from corporately owned
-                  and managed devices. These devices provide sufficient separation,
-                  using a risk-based approach, from the activities of standard users.
-                B2.b.7: You have sought to understand the security properties of third-
-                  party devices and networks before they can be connected to your
-                  systems. You have taken appropriate steps to mitigate any risks
-                  identified.
-                B2.b.8: The act of connecting to a network port or cable does not
-                  grant access to any systems.
-                B2.b.9: You are able to detect unknown devices being connected to
-                  your network and information systems and investigate such incidents.
+                B2.b.5:
+                  description: Only corporately owned and managed devices can access
+                    your essential function(s) network and information systems.
+                B2.b.6:
+                  description: All privileged operations are performed from corporately
+                    owned and managed devices. These devices provide sufficient separation,
+                    using a risk-based approach, from the activities of standard users.
+                B2.b.7:
+                  description: You have sought to understand the security properties
+                    of third- party devices and networks before they can be connected
+                    to your systems. You have taken appropriate steps to mitigate
+                    any risks identified.
+                B2.b.8:
+                  description: The act of connecting to a network port or cable does
+                    not grant access to any systems.
+                B2.b.9:
+                  description: You are able to detect unknown devices being connected
+                    to your network and information systems and investigate such incidents.
               achieved:
-                B2.b.10: All privileged operations performed on your network and information
-                  systems supporting your essential function(s) are conducted from
-                  highly trusted devices, such as Privileged Access Workstations,
-                  dedicated solely to those operations.
-                B2.b.11: You either obtain independent and professional assurance
-                  of the security of third-party devices or networks before they connect
-                  to your network and information systems, or you only allow third-party
-                  devices or networks that are dedicated to supporting your network
-                  and information systems to connect.
-                B2.b.12: You perform certificate-based device identity management
-                  and only allow known devices to access systems necessary for the
-                  operation of your essential function(s).
-                B2.b.13: You perform regular scans to detect unknown devices and investigate
-                  any findings.
+                B2.b.10:
+                  description: All privileged operations performed on your network
+                    and information systems supporting your essential function(s)
+                    are conducted from highly trusted devices, such as Privileged
+                    Access Workstations, dedicated solely to those operations.
+                B2.b.11:
+                  description: You either obtain independent and professional assurance
+                    of the security of third-party devices or networks before they
+                    connect to your network and information systems, or you only allow
+                    third-party devices or networks that are dedicated to supporting
+                    your network and information systems to connect.
+                B2.b.12:
+                  description: You perform certificate-based device identity management
+                    and only allow known devices to access systems necessary for the
+                    operation of your essential function(s).
+                B2.b.13:
+                  description: You perform regular scans to detect unknown devices
+                    and investigate any findings.
             assessment-rules: *standard-rules
           B2.c:
             code: B2.c
@@ -561,48 +704,66 @@ objectives:
               information systems supporting your essential function(s).
             indicators:
               not-achieved:
-                B2.c.1: The identities of the individuals with privileged access to
-                  network and information systems (infrastructure, platforms, software,
-                  configuration etc) supporting your essential function(s) are not
-                  known or not managed.
-                B2.c.2: Privileged user access to network and information systems
-                  supporting your essential function(s) is via weak authentication
-                  mechanisms (e.g. only simple passwords).
-                B2.c.3: The list of privileged users has not been reviewed recently
-                  (e.g. within the last 12 months).
-                B2.c.4: Privileged user access is granted on a system-wide basis rather
-                  than by role or function(s).
-                B2.c.5: Privileged user access to your essential function(s) is via
-                  generic, shared or default name accounts.
-                B2.c.6: Where there are "always on" terminals which can perform privileged
-                  actions (such as in a control room), there are no additional controls
-                  (e.g. physical controls) to ensure access is appropriately restricted.
-                B2.c.7: There is no logical separation between roles that an individual
-                  may have and hence the actions they perform (e.g. access to corporate
-                  email and privilege user actions).
+                B2.c.1:
+                  description: The identities of the individuals with privileged access
+                    to network and information systems (infrastructure, platforms,
+                    software, configuration etc) supporting your essential function(s)
+                    are not known or not managed.
+                B2.c.2:
+                  description: Privileged user access to network and information systems
+                    supporting your essential function(s) is via weak authentication
+                    mechanisms (e.g. only simple passwords).
+                B2.c.3:
+                  description: The list of privileged users has not been reviewed
+                    recently (e.g. within the last 12 months).
+                B2.c.4:
+                  description: Privileged user access is granted on a system-wide
+                    basis rather than by role or function(s).
+                B2.c.5:
+                  description: Privileged user access to your essential function(s)
+                    is via generic, shared or default name accounts.
+                B2.c.6:
+                  description: Where there are "always on" terminals which can perform
+                    privileged actions (such as in a control room), there are no additional
+                    controls (e.g. physical controls) to ensure access is appropriately
+                    restricted.
+                B2.c.7:
+                  description: There is no logical separation between roles that an
+                    individual may have and hence the actions they perform (e.g. access
+                    to corporate email and privilege user actions).
               partially-achieved:
-                B2.c.8: All privileged user access to network and information systems
-                  supporting your essential function(s) requires strong authentication,
-                  such as multi-factor (MFA).
-                B2.c.9: The identities of the individuals with privileged access to
-                  network and information systems (infrastructure, platforms, software,
-                  configuration etc) supporting your essential function(s) are known
-                  and managed. This includes third parties.
-                B2.c.10: Activity by privileged users is routinely reviewed and validated
-                  (e.g. at least annually).
-                B2.c.11: Privileged users are only granted specific privileged user
-                  access rights which are essential to their business role or function.
+                B2.c.8:
+                  description: All privileged user access to network and information
+                    systems supporting your essential function(s) requires strong
+                    authentication, such as multi-factor (MFA).
+                B2.c.9:
+                  description: The identities of the individuals with privileged access
+                    to network and information systems (infrastructure, platforms,
+                    software, configuration etc) supporting your essential function(s)
+                    are known and managed. This includes third parties.
+                B2.c.10:
+                  description: Activity by privileged users is routinely reviewed
+                    and validated (e.g. at least annually).
+                B2.c.11:
+                  description: Privileged users are only granted specific privileged
+                    user access rights which are essential to their business role
+                    or function.
               achieved:
-                B2.c.12: Privileged user access to network and information systems
-                  supporting your essential function(s) is carried out from dedicated
-                  separate accounts that are closely monitored and managed.
-                B2.c.13: The issuing of temporary, time- bound rights for privileged
-                  user access and / or external third- party support access is in
-                  place.
-                B2.c.14: Privileged user access rights are regularly reviewed and
-                  always updated as part of your joiners, movers and leavers process.
-                B2.c.15: All privileged user activity is routinely reviewed, validated
-                  and recorded for offline analysis and investigation.
+                B2.c.12:
+                  description: Privileged user access to network and information systems
+                    supporting your essential function(s) is carried out from dedicated
+                    separate accounts that are closely monitored and managed.
+                B2.c.13:
+                  description: The issuing of temporary, time- bound rights for privileged
+                    user access and / or external third- party support access is in
+                    place.
+                B2.c.14:
+                  description: Privileged user access rights are regularly reviewed
+                    and always updated as part of your joiners, movers and leavers
+                    process.
+                B2.c.15:
+                  description: All privileged user activity is routinely reviewed,
+                    validated and recorded for offline analysis and investigation.
             assessment-rules: *standard-rules
           B2.d:
             code: B2.d
@@ -612,38 +773,54 @@ objectives:
               systems supporting your essential function(s).
             indicators:
               not-achieved:
-                B2.d.1: Greater access rights are granted than necessary.
-                B2.d.2: Identity validation and requirement for access of a user,
-                  device or systems is not carried out.
-                B2.d.3: User access rights are not reviewed when users change roles.
-                B2.d.4: User access rights remain active when users leave your organisation.
-                B2.d.5: Access rights granted to devices or systems to access other
-                  devices and systems are not reviewed on a regular basis (at least
-                  annually).
+                B2.d.1:
+                  description: Greater access rights are granted than necessary.
+                B2.d.2:
+                  description: Identity validation and requirement for access of a
+                    user, device or systems is not carried out.
+                B2.d.3:
+                  description: User access rights are not reviewed when users change
+                    roles.
+                B2.d.4:
+                  description: User access rights remain active when users leave your
+                    organisation.
+                B2.d.5:
+                  description: Access rights granted to devices or systems to access
+                    other devices and systems are not reviewed on a regular basis
+                    (at least annually).
               partially-achieved:
-                B2.d.6: You follow a robust procedure to verify each user and issue
-                  the minimum required access rights.
-                B2.d.7: You regularly review access rights and those no longer needed
-                  are revoked.
-                B2.d.8: User access rights are reviewed when users change roles via
-                  your joiners, leavers and movers process.
-                B2.d.9: All user, device and system access to the systems supporting
-                  the essential function(s) is logged and monitored, but it is not
-                  compared to other log data or access records.
+                B2.d.6:
+                  description: You follow a robust procedure to verify each user and
+                    issue the minimum required access rights.
+                B2.d.7:
+                  description: You regularly review access rights and those no longer
+                    needed are revoked.
+                B2.d.8:
+                  description: User access rights are reviewed when users change roles
+                    via your joiners, leavers and movers process.
+                B2.d.9:
+                  description: All user, device and system access to the systems supporting
+                    the essential function(s) is logged and monitored, but it is not
+                    compared to other log data or access records.
               achieved:
-                B2.d.10: You follow a robust procedure to verify each user and issue
-                  the minimum required access rights, and the application of the procedure
-                  is regularly audited.
-                B2.d.11: User access rights are reviewed both when people change roles
-                  via your joiners, leavers and movers process and at regular intervals
-                  - at least annually.
-                B2.d.12: All user, device and systems access to the systems supporting
-                  the essential function(s) is logged and monitored.
-                B2.d.13: You regularly review access logs and correlate this data
-                  with other access records and expected activity.
-                B2.d.14: Attempts by unauthorised users, devices or systems to connect
-                  to the systems supporting the essential function(s) are alerted,
-                  promptly assessed and investigated.
+                B2.d.10:
+                  description: You follow a robust procedure to verify each user and
+                    issue the minimum required access rights, and the application
+                    of the procedure is regularly audited.
+                B2.d.11:
+                  description: User access rights are reviewed both when people change
+                    roles via your joiners, leavers and movers process and at regular
+                    intervals - at least annually.
+                B2.d.12:
+                  description: All user, device and systems access to the systems
+                    supporting the essential function(s) is logged and monitored.
+                B2.d.13:
+                  description: You regularly review access logs and correlate this
+                    data with other access records and expected activity.
+                B2.d.14:
+                  description: Attempts by unauthorised users, devices or systems
+                    to connect to the systems supporting the essential function(s)
+                    are alerted, promptly assessed and investigated.
             assessment-rules: *standard-rules
       B3:
         code: B3
@@ -667,52 +844,72 @@ objectives:
               of your essential function(s).
             indicators:
               not-achieved:
-                B3.a.1: You have incomplete knowledge of what data is used by and
-                  produced in the operation of the essential function(s).
-                B3.a.2: You have not identified the important data on which your essential
-                  function(s) relies.
-                B3.a.3: You have not identified who has access to data important to
-                  the operation of the essential function(s).
-                B3.a.4: You have not clearly articulated the impact of data compromise
-                  or lack of availability.
+                B3.a.1:
+                  description: You have incomplete knowledge of what data is used
+                    by and produced in the operation of the essential function(s).
+                B3.a.2:
+                  description: You have not identified the important data on which
+                    your essential function(s) relies.
+                B3.a.3:
+                  description: You have not identified who has access to data important
+                    to the operation of the essential function(s).
+                B3.a.4:
+                  description: You have not clearly articulated the impact of data
+                    compromise or lack of availability.
               partially-achieved:
-                B3.a.5: You have identified and catalogued all the data important
-                  to the operation of the essential function(s), or that would assist
-                  an attacker.
-                B3.a.6: You have identified and catalogued who has access to the data
-                  important to the operation of the essential function(s).
-                B3.a.7: You regularly review location, transmission, quantity and
-                  quality of data important to the operation of the essential function(s).
-                B3.a.8: You have identified all mobile devices and media that hold
-                  data important to the operation of the essential function(s).
-                B3.a.9: You understand and document the impact on your essential function(s)
-                  of all relevant scenarios, including unauthorised data access, modification
-                  or deletion, or when authorised users are unable to appropriately
-                  access this data.
-                B3.a.10: You occasionally validate these documented impact statements.
+                B3.a.5:
+                  description: You have identified and catalogued all the data important
+                    to the operation of the essential function(s), or that would assist
+                    an attacker.
+                B3.a.6:
+                  description: You have identified and catalogued who has access to
+                    the data important to the operation of the essential function(s).
+                B3.a.7:
+                  description: You regularly review location, transmission, quantity
+                    and quality of data important to the operation of the essential
+                    function(s).
+                B3.a.8:
+                  description: You have identified all mobile devices and media that
+                    hold data important to the operation of the essential function(s).
+                B3.a.9:
+                  description: You understand and document the impact on your essential
+                    function(s) of all relevant scenarios, including unauthorised
+                    data access, modification or deletion, or when authorised users
+                    are unable to appropriately access this data.
+                B3.a.10:
+                  description: You occasionally validate these documented impact statements.
               achieved:
-                B3.a.11: You have identified and catalogued all the data important
-                  to the operation of the essential function(s), or that would assist
-                  an attacker.
-                B3.a.12: You have identified and catalogued who has access to the
-                  data important to the operation of the essential function(s).
-                B3.a.13: You maintain a current understanding of the location, quantity
-                  and quality of data important to the operation of the essential
-                  function(s).
-                B3.a.14: You take steps to remove or minimise unnecessary copies or
-                  unneeded historic data.
-                B3.a.15: You have identified all mobile devices and media that may
-                  hold data important to the operation of the essential function(s).
-                B3.a.16: You maintain a current understanding of the data links used
-                  to transmit data that is important to your essential function(s).
-                B3.a.17: You understand the context, limitations and dependencies
-                  of your important data.
-                B3.a.18: You understand and document the impact on your essential
-                  function(s) of all relevant scenarios, including unauthorised data
-                  access, modification or deletion, or when authorised users are unable
-                  to appropriately access this data.
-                B3.a.19: You validate these documented impact statements regularly,
-                  at least annually.
+                B3.a.11:
+                  description: You have identified and catalogued all the data important
+                    to the operation of the essential function(s), or that would assist
+                    an attacker.
+                B3.a.12:
+                  description: You have identified and catalogued who has access to
+                    the data important to the operation of the essential function(s).
+                B3.a.13:
+                  description: You maintain a current understanding of the location,
+                    quantity and quality of data important to the operation of the
+                    essential function(s).
+                B3.a.14:
+                  description: You take steps to remove or minimise unnecessary copies
+                    or unneeded historic data.
+                B3.a.15:
+                  description: You have identified all mobile devices and media that
+                    may hold data important to the operation of the essential function(s).
+                B3.a.16:
+                  description: You maintain a current understanding of the data links
+                    used to transmit data that is important to your essential function(s).
+                B3.a.17:
+                  description: You understand the context, limitations and dependencies
+                    of your important data.
+                B3.a.18:
+                  description: You understand and document the impact on your essential
+                    function(s) of all relevant scenarios, including unauthorised
+                    data access, modification or deletion, or when authorised users
+                    are unable to appropriately access this data.
+                B3.a.19:
+                  description: You validate these documented impact statements regularly,
+                    at least annually.
             assessment-rules: *standard-rules
           B3.b:
             code: B3.b
@@ -722,33 +919,42 @@ objectives:
               third parties.
             indicators:
               not-achieved:
-                B3.b.1: You do not know what all your data links are, or which carry
-                  data important to the operation of the essential function(s).
-                B3.b.2: Data important to the operation of the essential function(s)
-                  travels without technical protection over non-trusted or openly
-                  accessible carriers.
-                B3.b.3: Critical data paths that could fail, be jammed, be overloaded,
-                  etc. have no alternative path.
+                B3.b.1:
+                  description: You do not know what all your data links are, or which
+                    carry data important to the operation of the essential function(s).
+                B3.b.2:
+                  description: Data important to the operation of the essential function(s)
+                    travels without technical protection over non-trusted or openly
+                    accessible carriers.
+                B3.b.3:
+                  description: Critical data paths that could fail, be jammed, be
+                    overloaded, etc. have no alternative path.
               partially-achieved:
-                B3.b.4: You have identified and protected (effectively and proportionately)
-                  all the data links that carry data important to the operation of
-                  your essential function(s).
-                B3.b.5: You apply appropriate technical means (e.g. cryptography)
-                  to protect data that travels over non-trusted or openly accessible
-                  carriers, but you have limited or no confidence in the robustness
-                  of the protection applied.
+                B3.b.4:
+                  description: You have identified and protected (effectively and
+                    proportionately) all the data links that carry data important
+                    to the operation of your essential function(s).
+                B3.b.5:
+                  description: You apply appropriate technical means (e.g. cryptography)
+                    to protect data that travels over non-trusted or openly accessible
+                    carriers, but you have limited or no confidence in the robustness
+                    of the protection applied.
               achieved:
-                B3.b.6: You have identified and protected (effectively and proportionately)
-                  all the data links that carry data important to the operation of
-                  your essential function(s).
-                B3.b.7: You apply appropriate physical and / or technical means to
-                  protect data that travels over non-trusted or openly accessible
-                  carriers, with justified confidence in the robustness of the protection
-                  applied.
-                B3.b.8: Suitable alternative transmission paths are available where
-                  there is a significant risk of impact on the operation of the essential
-                  function(s) due to resource limitation (e.g. transmission equipment
-                  or function failure, or important data being blocked or jammed).
+                B3.b.6:
+                  description: You have identified and protected (effectively and
+                    proportionately) all the data links that carry data important
+                    to the operation of your essential function(s).
+                B3.b.7:
+                  description: You apply appropriate physical and / or technical means
+                    to protect data that travels over non-trusted or openly accessible
+                    carriers, with justified confidence in the robustness of the protection
+                    applied.
+                B3.b.8:
+                  description: Suitable alternative transmission paths are available
+                    where there is a significant risk of impact on the operation of
+                    the essential function(s) due to resource limitation (e.g. transmission
+                    equipment or function failure, or important data being blocked
+                    or jammed).
             assessment-rules: *standard-rules
           B3.c:
             code: B3.c
@@ -757,45 +963,59 @@ objectives:
               to the operation of your essential function(s).
             indicators:
               not-achieved:
-                B3.c.1: You have no, or limited, knowledge of where data important
-                  to the operation of the essential function(s) is stored.
-                B3.c.2: You have not protected vulnerable stored data important to
-                  the operation of the essential function(s) in a suitable way.
-                B3.c.3: Backups are incomplete, untested, not adequately secured or
-                  could be inaccessible in a disaster recovery or business continuity
-                  situation.
+                B3.c.1:
+                  description: You have no, or limited, knowledge of where data important
+                    to the operation of the essential function(s) is stored.
+                B3.c.2:
+                  description: You have not protected vulnerable stored data important
+                    to the operation of the essential function(s) in a suitable way.
+                B3.c.3:
+                  description: Backups are incomplete, untested, not adequately secured
+                    or could be inaccessible in a disaster recovery or business continuity
+                    situation.
               partially-achieved:
-                B3.c.4: All copies of data important to the operation of your essential
-                  function(s) are necessary. Where this important data is transferred
-                  to less secure systems, the data is provided with limited detail
-                  and / or as a read-only copy.
-                B3.c.5: You have applied suitable physical and / or technical means
-                  to protect this important stored data from unauthorised access,
-                  modification or deletion.
-                B3.c.6: If cryptographic protections are used, you apply suitable
-                  technical and procedural means, but you have limited or no confidence
-                  in the robustness of the protection applied.
-                B3.c.7: You have suitable, secured backups of data to allow the operation
-                  of the essential function(s) to continue should the original data
-                  not be available. This may include off- line or segregated backups,
-                  or appropriate alternative forms such as paper copies.
+                B3.c.4:
+                  description: All copies of data important to the operation of your
+                    essential function(s) are necessary. Where this important data
+                    is transferred to less secure systems, the data is provided with
+                    limited detail and / or as a read-only copy.
+                B3.c.5:
+                  description: You have applied suitable physical and / or technical
+                    means to protect this important stored data from unauthorised
+                    access, modification or deletion.
+                B3.c.6:
+                  description: If cryptographic protections are used, you apply suitable
+                    technical and procedural means, but you have limited or no confidence
+                    in the robustness of the protection applied.
+                B3.c.7:
+                  description: You have suitable, secured backups of data to allow
+                    the operation of the essential function(s) to continue should
+                    the original data not be available. This may include off- line
+                    or segregated backups, or appropriate alternative forms such as
+                    paper copies.
               achieved:
-                B3.c.8: All copies of data important to the operation of your essential
-                  function(s) are necessary. Where this important data is transferred
-                  to less secure systems, the data is provided with limited detail
-                  and / or as a read-only copy.
-                B3.c.9: You have applied suitable physical and / or technical means
-                  to protect this important stored data from unauthorised access,
-                  modification or deletion.
-                B3.c.10: If cryptographic protections are used you apply suitable
-                  technical and procedural means, and you have justified confidence
-                  in the robustness of the protection applied.
-                B3.c.11: You have suitable, secured backups of data to allow the operation
-                  of the essential function(s) to continue should the original data
-                  not be available. This may include off- line or segregated backups,
-                  or appropriate alternative forms such as paper copies.
-                B3.c.12: Necessary historic or archive data is suitably secured in
-                  storage.
+                B3.c.8:
+                  description: All copies of data important to the operation of your
+                    essential function(s) are necessary. Where this important data
+                    is transferred to less secure systems, the data is provided with
+                    limited detail and / or as a read-only copy.
+                B3.c.9:
+                  description: You have applied suitable physical and / or technical
+                    means to protect this important stored data from unauthorised
+                    access, modification or deletion.
+                B3.c.10:
+                  description: If cryptographic protections are used you apply suitable
+                    technical and procedural means, and you have justified confidence
+                    in the robustness of the protection applied.
+                B3.c.11:
+                  description: You have suitable, secured backups of data to allow
+                    the operation of the essential function(s) to continue should
+                    the original data not be available. This may include off- line
+                    or segregated backups, or appropriate alternative forms such as
+                    paper copies.
+                B3.c.12:
+                  description: Necessary historic or archive data is suitably secured
+                    in storage.
             assessment-rules: *standard-rules
           B3.d:
             code: B3.d
@@ -804,30 +1024,40 @@ objectives:
               essential function(s) on mobile devices.
             indicators:
               not-achieved:
-                B3.d.1: You don't know which mobile devices may hold data important
-                  to the operation of the essential function(s).
-                B3.d.2: You allow data important to the operation of the essential
-                  function(s) to be stored on devices not managed by your organisation,
-                  or to at least equivalent standard.
-                B3.d.3: Data on mobile devices is not technically secured, or only
-                  some is secured.
+                B3.d.1:
+                  description: You don't know which mobile devices may hold data important
+                    to the operation of the essential function(s).
+                B3.d.2:
+                  description: You allow data important to the operation of the essential
+                    function(s) to be stored on devices not managed by your organisation,
+                    or to at least equivalent standard.
+                B3.d.3:
+                  description: Data on mobile devices is not technically secured,
+                    or only some is secured.
               partially-achieved:
-                B3.d.4: You know which mobile devices hold data important to the operation
-                  of the essential function(s).
-                B3.d.5: Data important to the operation of the essential function(s)
-                  is stored on mobile devices only when they have at least the security
-                  standard aligned to your overarching security policies.
-                B3.d.6: Data on mobile devices is technically secured.
+                B3.d.4:
+                  description: You know which mobile devices hold data important to
+                    the operation of the essential function(s).
+                B3.d.5:
+                  description: Data important to the operation of the essential function(s)
+                    is stored on mobile devices only when they have at least the security
+                    standard aligned to your overarching security policies.
+                B3.d.6:
+                  description: Data on mobile devices is technically secured.
               achieved:
-                B3.d.7: Mobile devices that hold data that is important to the operation
-                  of the essential function(s) are catalogued, are under your organisation's
-                  control and configured according to best practice for the platform,
-                  with appropriate technical and procedural policies in place.
-                B3.d.8: Your organisation can remotely wipe all mobile devices holding
-                  data important to the operation of the essential function(s).
-                B3.d.9: You have minimised this data on these mobile devices. Some
-                  data may be automatically deleted off mobile devices after a certain
-                  period.
+                B3.d.7:
+                  description: Mobile devices that hold data that is important to
+                    the operation of the essential function(s) are catalogued, are
+                    under your organisation's control and configured according to
+                    best practice for the platform, with appropriate technical and
+                    procedural policies in place.
+                B3.d.8:
+                  description: Your organisation can remotely wipe all mobile devices
+                    holding data important to the operation of the essential function(s).
+                B3.d.9:
+                  description: You have minimised this data on these mobile devices.
+                    Some data may be automatically deleted off mobile devices after
+                    a certain period.
             assessment-rules: *standard-rules
           B3.e:
             code: B3.e
@@ -837,20 +1067,24 @@ objectives:
               operation of your essential function(s).
             indicators:
               not-achieved:
-                B3.e.1: Some or all devices, equipment or removable media that hold
-                  data important to the operation of the essential function(s) are
-                  reused or disposed of without sanitisation of that data.
+                B3.e.1:
+                  description: Some or all devices, equipment or removable media that
+                    hold data important to the operation of the essential function(s)
+                    are reused or disposed of without sanitisation of that data.
               partially-achieved:
-                B3.e.2: Data important to the operations of the essential function(s)
-                  is removed from all devices, equipment and removable media before
-                  reuse and / or disposal.
+                B3.e.2:
+                  description: Data important to the operations of the essential function(s)
+                    is removed from all devices, equipment and removable media before
+                    reuse and / or disposal.
               achieved:
-                B3.e.3: You catalogue and track all devices that contain data important
-                  to the operation of the essential function(s) (whether a specific
-                  storage device or one with integral storage).
-                B3.e.4: Data important to the operation of the essential function(s)
-                  is removed from all devices, equipment and removable media before
-                  reuse and / or disposal using an assured product or service.
+                B3.e.3:
+                  description: You catalogue and track all devices that contain data
+                    important to the operation of the essential function(s) (whether
+                    a specific storage device or one with integral storage).
+                B3.e.4:
+                  description: Data important to the operation of the essential function(s)
+                    is removed from all devices, equipment and removable media before
+                    reuse and / or disposal using an assured product or service.
             assessment-rules: *standard-rules
       B4:
         code: B4
@@ -871,45 +1105,60 @@ objectives:
               vulnerability.
             indicators:
               not-achieved:
-                B4.a.1: Systems essential to the operation of the essential function(s)
-                  are not appropriately segregated from other systems.
-                B4.a.2: Internet access is available from network and information
-                  systems supporting your essential function(s).
-                B4.a.3: Data flows between network and information systems supporting
-                  your essential function(s) and other systems are complex, making
-                  it hard to discriminate between legitimate and illegitimate / malicious
-                  traffic.
-                B4.a.4: Remote or third-party accesses circumvent some network controls
-                  to gain more direct access to network and information systems supporting
-                  the essential function(s).
+                B4.a.1:
+                  description: Systems essential to the operation of the essential
+                    function(s) are not appropriately segregated from other systems.
+                B4.a.2:
+                  description: Internet access is available from network and information
+                    systems supporting your essential function(s).
+                B4.a.3:
+                  description: Data flows between network and information systems
+                    supporting your essential function(s) and other systems are complex,
+                    making it hard to discriminate between legitimate and illegitimate
+                    / malicious traffic.
+                B4.a.4:
+                  description: Remote or third-party accesses circumvent some network
+                    controls to gain more direct access to network and information
+                    systems supporting the essential function(s).
               partially-achieved:
-                B4.a.5: You employ appropriate expertise to design network and information
-                  systems.
-                B4.a.6: You design strong boundary defences where your network and
-                  information systems interface with other organisations or the world
-                  at large.
-                B4.a.7: You design simple data flows between your network and information
-                  systems and any external interface to enable effective monitoring.
-                B4.a.8: You design to make network and information system recovery
-                  simple.
-                B4.a.9: All inputs to network and information systems supporting your
-                  essential function(s) are checked and validated at the network boundary
-                  where possible, or additional monitoring is in place for content-based
-                  attacks.
+                B4.a.5:
+                  description: You employ appropriate expertise to design network
+                    and information systems.
+                B4.a.6:
+                  description: You design strong boundary defences where your network
+                    and information systems interface with other organisations or
+                    the world at large.
+                B4.a.7:
+                  description: You design simple data flows between your network and
+                    information systems and any external interface to enable effective
+                    monitoring.
+                B4.a.8:
+                  description: You design to make network and information system recovery
+                    simple.
+                B4.a.9:
+                  description: All inputs to network and information systems supporting
+                    your essential function(s) are checked and validated at the network
+                    boundary where possible, or additional monitoring is in place
+                    for content-based attacks.
               achieved:
-                B4.a.10: You employ appropriate expertise to design network and information
-                  systems.
-                B4.a.11: Your network and information systems are segregated into
-                  appropriate security zones (e.g. systems supporting the essential
-                  function(s) are segregated in a highly trusted, more secure zone).
-                B4.a.12: The network and information systems supporting your essential
-                  function(s) are designed to have simple data flows between components
-                  to support effective security monitoring.
-                B4.a.13: The network and information systems supporting your essential
-                  function(s) are designed to be easy to recover.
-                B4.a.14: Content-based attacks are mitigated for all inputs to network
-                  and information systems that affect the essential function(s) (e.g.
-                  via transformation and inspection).
+                B4.a.10:
+                  description: You employ appropriate expertise to design network
+                    and information systems.
+                B4.a.11:
+                  description: Your network and information systems are segregated
+                    into appropriate security zones (e.g. systems supporting the essential
+                    function(s) are segregated in a highly trusted, more secure zone).
+                B4.a.12:
+                  description: The network and information systems supporting your
+                    essential function(s) are designed to have simple data flows between
+                    components to support effective security monitoring.
+                B4.a.13:
+                  description: The network and information systems supporting your
+                    essential function(s) are designed to be easy to recover.
+                B4.a.14:
+                  description: Content-based attacks are mitigated for all inputs
+                    to network and information systems that affect the essential function(s)
+                    (e.g. via transformation and inspection).
             assessment-rules: *standard-rules
           B4.b:
             code: B4.b
@@ -918,50 +1167,73 @@ objectives:
               that support the operation of your essential function(s).
             indicators:
               not-achieved:
-                B4.b.1: You haven't identified the assets that need to be carefully
-                  configured to maintain the security of the essential function(s).
-                B4.b.2: Policies relating to the security of operating system builds
-                  or configuration are not applied consistently across your network
-                  and information systems relating to your essential function(s).
-                B4.b.3: Configuration details are not recorded or lack enough information
-                  to be able to rebuild the system or device.
-                B4.b.4: The recording of security changes or adjustments that affect
-                  your essential function(s) is lacking or inconsistent.
-                B4.b.5: Generic, shared, default name and built-in accounts have not
-                  been removed or disabled.
+                B4.b.1:
+                  description: You haven't identified the assets that need to be carefully
+                    configured to maintain the security of the essential function(s).
+                B4.b.2:
+                  description: Policies relating to the security of operating system
+                    builds or configuration are not applied consistently across your
+                    network and information systems relating to your essential function(s).
+                B4.b.3:
+                  description: Configuration details are not recorded or lack enough
+                    information to be able to rebuild the system or device.
+                B4.b.4:
+                  description: The recording of security changes or adjustments that
+                    affect your essential function(s) is lacking or inconsistent.
+                B4.b.5:
+                  description: Generic, shared, default name and built-in accounts
+                    have not been removed or disabled.
               partially-achieved:
-                B4.b.6: You have identified and documented the assets that need to
-                  be carefully configured to maintain the security of the essential
-                  function(s).
-                B4.b.7: Secure platform and device builds are used across the estate.
-                B4.b.8: Consistent, secure and minimal system and device configurations
-                  are applied across the same types of environment.
-                B4.b.9: Changes and adjustments to security configuration at security
-                  boundaries with the network and information systems supporting your
-                  essential function(s) are approved and documented.
-                B4.b.10: You verify software before installation is permitted.
-                B4.b.11: Generic, shared, default name and built-in accounts have
-                  been removed or disabled. Where this is not possible, credentials
-                  to these accounts have been changed.
+                B4.b.6:
+                  description: You have identified and documented the assets that
+                    need to be carefully configured to maintain the security of the
+                    essential function(s).
+                B4.b.7:
+                  description: Secure platform and device builds are used across the
+                    estate.
+                B4.b.8:
+                  description: Consistent, secure and minimal system and device configurations
+                    are applied across the same types of environment.
+                B4.b.9:
+                  description: Changes and adjustments to security configuration at
+                    security boundaries with the network and information systems supporting
+                    your essential function(s) are approved and documented.
+                B4.b.10:
+                  description: You verify software before installation is permitted.
+                B4.b.11:
+                  description: Generic, shared, default name and built-in accounts
+                    have been removed or disabled. Where this is not possible, credentials
+                    to these accounts have been changed.
               achieved:
-                B4.b.12: You have identified, documented and actively manage (e.g.
-                  maintain security configurations, patching, updating according to
-                  good practice) the assets that need to be carefully configured to
-                  maintain the security of the essential function(s).
-                B4.b.13: All platforms conform to your secure, defined baseline build,
-                  or the latest known good configuration version for that environment.
-                B4.b.14: You closely and effectively manage changes in your environment,
-                  ensuring that network and system configurations are secure and documented.
-                B4.b.15: You regularly review and validate that your network and information
-                  systems have the expected, secure settings and configuration.
-                B4.b.16: Only permitted software can be installed.
-                B4.b.17: Standard users are not able to change settings that would
-                  impact security or the business operation.
-                B4.b.18: If automated decision-making technologies are in use, their
-                  operation is well understood, and decisions can be replicated.
-                B4.b.19: Generic, shared, default name and built-in accounts have
-                  been removed or disabled. Where this is not possible, credentials
-                  to these accounts have been changed.
+                B4.b.12:
+                  description: You have identified, documented and actively manage
+                    (e.g. maintain security configurations, patching, updating according
+                    to good practice) the assets that need to be carefully configured
+                    to maintain the security of the essential function(s).
+                B4.b.13:
+                  description: All platforms conform to your secure, defined baseline
+                    build, or the latest known good configuration version for that
+                    environment.
+                B4.b.14:
+                  description: You closely and effectively manage changes in your
+                    environment, ensuring that network and system configurations are
+                    secure and documented.
+                B4.b.15:
+                  description: You regularly review and validate that your network
+                    and information systems have the expected, secure settings and
+                    configuration.
+                B4.b.16:
+                  description: Only permitted software can be installed.
+                B4.b.17:
+                  description: Standard users are not able to change settings that
+                    would impact security or the business operation.
+                B4.b.18:
+                  description: If automated decision-making technologies are in use,
+                    their operation is well understood, and decisions can be replicated.
+                B4.b.19:
+                  description: Generic, shared, default name and built-in accounts
+                    have been removed or disabled. Where this is not possible, credentials
+                    to these accounts have been changed.
             assessment-rules: *standard-rules
           B4.c:
             code: B4.c
@@ -971,30 +1243,40 @@ objectives:
               maintain security.
             indicators:
               not-achieved:
-                B4.c.1: Your systems and devices supporting the operation of the essential
-                  function(s) are administered or maintained from devices that are
-                  not corporately owned and managed.
-                B4.c.2: You do not have good or current technical documentation of
-                  your network and information systems.
+                B4.c.1:
+                  description: Your systems and devices supporting the operation of
+                    the essential function(s) are administered or maintained from
+                    devices that are not corporately owned and managed.
+                B4.c.2:
+                  description: You do not have good or current technical documentation
+                    of your network and information systems.
               partially-achieved:
-                B4.c.3: Your systems and devices supporting the operation of the essential
-                  function(s) are only administered or maintained by authorised privileged
-                  users from devices sufficiently separated, using a risk-based approach,
-                  from the activities of standard users.
-                B4.c.4: Technical knowledge about network and information systems,
-                  such as documentation and network diagrams, is regularly reviewed
-                  and updated.
-                B4.c.5: You prevent, detect and remove malware, and unauthorised software.
-                  You use technical, procedural and physical measures as necessary.
+                B4.c.3:
+                  description: Your systems and devices supporting the operation of
+                    the essential function(s) are only administered or maintained
+                    by authorised privileged users from devices sufficiently separated,
+                    using a risk-based approach, from the activities of standard users.
+                B4.c.4:
+                  description: Technical knowledge about network and information systems,
+                    such as documentation and network diagrams, is regularly reviewed
+                    and updated.
+                B4.c.5:
+                  description: You prevent, detect and remove malware, and unauthorised
+                    software. You use technical, procedural and physical measures
+                    as necessary.
               achieved:
-                B4.c.6: Your systems and devices supporting the operation of the essential
-                  function(s) are only administered or maintained by authorised privileged
-                  users from highly trusted devices, such as Privileged Access Workstations,
-                  dedicated solely to those operations.
-                B4.c.7: You regularly review and update technical knowledge about
-                  network and information systems, such as documentation
-                B4.c.8: You prevent, detect and remove malware, and unauthorised software.
-                  You use technical, procedural and physical measures as necessary.
+                B4.c.6:
+                  description: Your systems and devices supporting the operation of
+                    the essential function(s) are only administered or maintained
+                    by authorised privileged users from highly trusted devices, such
+                    as Privileged Access Workstations, dedicated solely to those operations.
+                B4.c.7:
+                  description: You regularly review and update technical knowledge
+                    about network and information systems, such as documentation
+                B4.c.8:
+                  description: You prevent, detect and remove malware, and unauthorised
+                    software. You use technical, procedural and physical measures
+                    as necessary.
             assessment-rules: *standard-rules
           B4.d:
             code: B4.d
@@ -1003,43 +1285,59 @@ objectives:
               systems to prevent adverse impact on your essential function(s).
             indicators:
               not-achieved:
-                B4.d.1: You do not understand the exposure of your essential function(s)
-                  to publicly-known vulnerabilities.
-                B4.d.2: You do not mitigate externally exposed vulnerabilities promptly.
-                B4.d.3: You have not recently tested to verify your understanding
-                  of the vulnerabilities of the network and information systems that
-                  support your essential function(s).
-                B4.d.4: You have not suitably mitigated systems or software that is
-                  no longer supported.
-                B4.d.5: You are not pursuing replacement for unsupported systems or
-                  software.
+                B4.d.1:
+                  description: You do not understand the exposure of your essential
+                    function(s) to publicly-known vulnerabilities.
+                B4.d.2:
+                  description: You do not mitigate externally exposed vulnerabilities
+                    promptly.
+                B4.d.3:
+                  description: You have not recently tested to verify your understanding
+                    of the vulnerabilities of the network and information systems
+                    that support your essential function(s).
+                B4.d.4:
+                  description: You have not suitably mitigated systems or software
+                    that is no longer supported.
+                B4.d.5:
+                  description: You are not pursuing replacement for unsupported systems
+                    or software.
               partially-achieved:
-                B4.d.6: You maintain a current understanding of the exposure of your
-                  essential function(s) to publicly-known vulnerabilities.
-                B4.d.7: Announced vulnerabilities for all software packages, network
-                  and information systems used to support your essential function(s)
-                  are tracked, prioritised and externally exposed vulnerabilities
-                  are mitigated (e.g. by patching) promptly.
-                B4.d.8: Some vulnerabilities that are not externally exposed have
-                  temporary mitigations for an extended period.
-                B4.d.9: You have temporary mitigations for unsupported systems and
-                  software while pursuing migration to supported technology.
-                B4.d.10: You regularly test to fully understand the vulnerabilities
-                  of the network and information systems that support the operation
-                  of your essential function(s).
+                B4.d.6:
+                  description: You maintain a current understanding of the exposure
+                    of your essential function(s) to publicly-known vulnerabilities.
+                B4.d.7:
+                  description: Announced vulnerabilities for all software packages,
+                    network and information systems used to support your essential
+                    function(s) are tracked, prioritised and externally exposed vulnerabilities
+                    are mitigated (e.g. by patching) promptly.
+                B4.d.8:
+                  description: Some vulnerabilities that are not externally exposed
+                    have temporary mitigations for an extended period.
+                B4.d.9:
+                  description: You have temporary mitigations for unsupported systems
+                    and software while pursuing migration to supported technology.
+                B4.d.10:
+                  description: You regularly test to fully understand the vulnerabilities
+                    of the network and information systems that support the operation
+                    of your essential function(s).
               achieved:
-                B4.d.11: You maintain a current understanding of the exposure of your
-                  essential function(s) to publicly-known vulnerabilities.
-                B4.d.12: Announced vulnerabilities for all software packages, network
-                  and information systems used to support your essential function(s)
-                  are tracked, prioritised and mitigated (e.g. by patching) promptly.
-                B4.d.13: You regularly test to fully understand the vulnerabilities
-                  of the network and information systems that support the operation
-                  of your essential function(s) and verify this understanding with
-                  third-party testing.
-                B4.d.14: You maximise the use of supported software, firmware and
-                  hardware in your network and information systems supporting your
-                  essential function(s).
+                B4.d.11:
+                  description: You maintain a current understanding of the exposure
+                    of your essential function(s) to publicly-known vulnerabilities.
+                B4.d.12:
+                  description: Announced vulnerabilities for all software packages,
+                    network and information systems used to support your essential
+                    function(s) are tracked, prioritised and mitigated (e.g. by patching)
+                    promptly.
+                B4.d.13:
+                  description: You regularly test to fully understand the vulnerabilities
+                    of the network and information systems that support the operation
+                    of your essential function(s) and verify this understanding with
+                    third-party testing.
+                B4.d.14:
+                  description: You maximise the use of supported software, firmware
+                    and hardware in your network and information systems supporting
+                    your essential function(s).
             assessment-rules: *standard-rules
       B5:
         code: B5
@@ -1055,30 +1353,38 @@ objectives:
               function(s) following adverse impact.
             indicators:
               not-achieved:
-                B5.a.1: You have limited understanding of all the elements that are
-                  required to restore operation of the essential function(s).
-                B5.a.2: You have not completed business continuity and disaster recovery
-                  plans for network and information systems, including their dependencies,
-                  supporting the operation of the essential function(s).
-                B5.a.3: You have not fully assessed the practical implementation of
-                  your business continuity and disaster recovery plans.
+                B5.a.1:
+                  description: You have limited understanding of all the elements
+                    that are required to restore operation of the essential function(s).
+                B5.a.2:
+                  description: You have not completed business continuity and disaster
+                    recovery plans for network and information systems, including
+                    their dependencies, supporting the operation of the essential
+                    function(s).
+                B5.a.3:
+                  description: You have not fully assessed the practical implementation
+                    of your business continuity and disaster recovery plans.
               partially-achieved:
-                B5.a.4: You know all network and information systems, and underlying
-                  technologies, that are necessary to restore the operation of the
-                  essential function(s) and understand their interdependence.
-                B5.a.5: You know the order in which systems need to be recovered to
-                  efficiently and effectively restore the operation of the essential
-                  function(s).
+                B5.a.4:
+                  description: You know all network and information systems, and underlying
+                    technologies, that are necessary to restore the operation of the
+                    essential function(s) and understand their interdependence.
+                B5.a.5:
+                  description: You know the order in which systems need to be recovered
+                    to efficiently and effectively restore the operation of the essential
+                    function(s).
               achieved:
-                B5.a.6: You have business continuity and disaster recovery plans that
-                  have been tested for practicality, effectiveness and completeness.
-                  Appropriate use is made of different test methods (e.g. manual fail-over,
-                  table-top exercises, or red-teaming).
-                B5.a.7: You use your security awareness and threat intelligence sources
-                  to identify new or heightened levels of risk, which result in immediate
-                  and potentially temporary security measures to enhance the security
-                  of your network and information systems (e.g. in response to a widespread
-                  outbreak of very damaging malware).
+                B5.a.6:
+                  description: You have business continuity and disaster recovery
+                    plans that have been tested for practicality, effectiveness and
+                    completeness. Appropriate use is made of different test methods
+                    (e.g. manual fail-over, table-top exercises, or red-teaming).
+                B5.a.7:
+                  description: You use your security awareness and threat intelligence
+                    sources to identify new or heightened levels of risk, which result
+                    in immediate and potentially temporary security measures to enhance
+                    the security of your network and information systems (e.g. in
+                    response to a widespread outbreak of very damaging malware).
             assessment-rules: *standard-rules
           B5.b:
             code: B5.b
@@ -1088,35 +1394,47 @@ objectives:
               Systems are appropriately segregated and resource limitations are mitigated.
             indicators:
               not-achieved:
-                B5.b.1: Network and information systems supporting the operation of
-                  your essential function(s) are not appropriately segregated.
-                B5.b.2: Internet services, such as browsing and email, are accessible
-                  from network and information systems supporting the essential function(s).
-                B5.b.3: You do not understand or lack plans to mitigate all resource
-                  limitations that could adversely affect your essential function(s).
+                B5.b.1:
+                  description: Network and information systems supporting the operation
+                    of your essential function(s) are not appropriately segregated.
+                B5.b.2:
+                  description: Internet services, such as browsing and email, are
+                    accessible from network and information systems supporting the
+                    essential function(s).
+                B5.b.3:
+                  description: You do not understand or lack plans to mitigate all
+                    resource limitations that could adversely affect your essential
+                    function(s).
               partially-achieved:
-                B5.b.4: Network and information systems supporting the operation of
-                  your essential function(s) are logically separated from your business
-                  systems (e.g. they reside on the same network as the rest of the
-                  organisation but within a DMZ). Internet services are not accessible
-                  from network and information systems supporting the essential function(s).
-                B5.b.5: Resource limitations (e.g. network bandwidth, single network
-                  paths) have been identified but not fully mitigated.
+                B5.b.4:
+                  description: Network and information systems supporting the operation
+                    of your essential function(s) are logically separated from your
+                    business systems (e.g. they reside on the same network as the
+                    rest of the organisation but within a DMZ). Internet services
+                    are not accessible from network and information systems supporting
+                    the essential function(s).
+                B5.b.5:
+                  description: Resource limitations (e.g. network bandwidth, single
+                    network paths) have been identified but not fully mitigated.
               achieved:
-                B5.b.6: Network and information systems supporting the operation of
-                  your essential function(s) are segregated from other business and
-                  external systems by appropriate technical and physical means (e.g.
-                  separate network and system infrastructure with independent user
-                  administration). Internet services are not accessible from network
-                  and information systems supporting the essential function(s).
-                B5.b.7: You have identified and mitigated all resource limitations
-                  (e.g. bandwidth limitations and single network paths).
-                B5.b.8: You have identified and mitigated any geographical constraints
-                  or weaknesses. (e.g. systems that your essential function(s) depends
-                  upon are replicated in another location, important network connectivity
-                  has alternative physical paths and service providers).
-                B5.b.9: You review and update assessments of dependencies, resource
-                  and geographical limitations and mitigations when necessary.
+                B5.b.6:
+                  description: Network and information systems supporting the operation
+                    of your essential function(s) are segregated from other business
+                    and external systems by appropriate technical and physical means
+                    (e.g. separate network and system infrastructure with independent
+                    user administration). Internet services are not accessible from
+                    network and information systems supporting the essential function(s).
+                B5.b.7:
+                  description: You have identified and mitigated all resource limitations
+                    (e.g. bandwidth limitations and single network paths).
+                B5.b.8:
+                  description: You have identified and mitigated any geographical
+                    constraints or weaknesses. (e.g. systems that your essential function(s)
+                    depends upon are replicated in another location, important network
+                    connectivity has alternative physical paths and service providers).
+                B5.b.9:
+                  description: You review and update assessments of dependencies,
+                    resource and geographical limitations and mitigations when necessary.
             assessment-rules: *standard-rules
           B5.c:
             code: B5.c
@@ -1125,26 +1443,34 @@ objectives:
               information needed to recover operation of your essential function(s).
             indicators:
               not-achieved:
-                B5.c.1: Backup coverage is incomplete and does not include all relevant
-                  data and information needed to restore the operation of your essential
-                  function(s).
-                B5.c.2: Backups are not frequent enough for the operation of your
-                  essential function(s) to be restored effectively.
-                B5.c.3: Your restoration process does not restore your essential function(s)
-                  in a suitable time frame.
+                B5.c.1:
+                  description: Backup coverage is incomplete and does not include
+                    all relevant data and information needed to restore the operation
+                    of your essential function(s).
+                B5.c.2:
+                  description: Backups are not frequent enough for the operation of
+                    your essential function(s) to be restored effectively.
+                B5.c.3:
+                  description: Your restoration process does not restore your essential
+                    function(s) in a suitable time frame.
               partially-achieved:
-                B5.c.4: You have appropriately secured backups (including data, configuration
-                  information, software, equipment, processes and knowledge). These
-                  backups will be accessible to recover from an extreme event.
-                B5.c.5: You routinely test backups to ensure that the backup process
-                  function(s) correctly and the backups are usable.
+                B5.c.4:
+                  description: You have appropriately secured backups (including data,
+                    configuration information, software, equipment, processes and
+                    knowledge). These backups will be accessible to recover from an
+                    extreme event.
+                B5.c.5:
+                  description: You routinely test backups to ensure that the backup
+                    process function(s) correctly and the backups are usable.
               achieved:
-                B5.c.6: Your comprehensive, automatic and tested technical and procedural
-                  backups are secured at centrally accessible or secondary sites to
-                  recover from an extreme event.
-                B5.c.7: Backups of all important data and information needed to recover
-                  the essential function(s) are made, tested, documented and routinely
-                  reviewed.
+                B5.c.6:
+                  description: Your comprehensive, automatic and tested technical
+                    and procedural backups are secured at centrally accessible or
+                    secondary sites to recover from an extreme event.
+                B5.c.7:
+                  description: Backups of all important data and information needed
+                    to recover the essential function(s) are made, tested, documented
+                    and routinely reviewed.
             assessment-rules: *standard-rules
       B6:
         code: B6
@@ -1159,39 +1485,54 @@ objectives:
             description: You develop and maintain a positive cyber security culture.
             indicators:
               not-achieved:
-                B6.a.1: People in your organisation don't understand what they contribute
-                  to the cyber security of the essential function(s).
-                B6.a.2: People in your organisation don't know how to raise a concern
-                  about cyber security.
-                B6.a.3: People believe that reporting issues may get them into trouble.
-                B6.a.4: Your organisation's approach to cyber security is perceived
-                  by staff as hindering the business of the organisation.
+                B6.a.1:
+                  description: People in your organisation don't understand what they
+                    contribute to the cyber security of the essential function(s).
+                B6.a.2:
+                  description: People in your organisation don't know how to raise
+                    a concern about cyber security.
+                B6.a.3:
+                  description: People believe that reporting issues may get them into
+                    trouble.
+                B6.a.4:
+                  description: Your organisation's approach to cyber security is perceived
+                    by staff as hindering the business of the organisation.
               partially-achieved:
-                B6.a.5: Your executive management understand and widely communicate
-                  the importance of a positive cyber security culture. Positive attitudes,
-                  behaviours and expectations are described for your organisation.
-                B6.a.6: All people in your organisation understand the contribution
-                  they make to the essential function(s) cyber security.
-                B6.a.7: All individuals in your organisation know who to contact and
-                  where to access more information about cyber security. They know
-                  how to raise a cyber security issue.
+                B6.a.5:
+                  description: Your executive management understand and widely communicate
+                    the importance of a positive cyber security culture. Positive
+                    attitudes, behaviours and expectations are described for your
+                    organisation.
+                B6.a.6:
+                  description: All people in your organisation understand the contribution
+                    they make to the essential function(s) cyber security.
+                B6.a.7:
+                  description: All individuals in your organisation know who to contact
+                    and where to access more information about cyber security. They
+                    know how to raise a cyber security issue.
               achieved:
-                B6.a.8: Your executive management clearly and effectively communicates
-                  the organisation's cyber security priorities and objectives to all
-                  staff. Your organisation displays positive cyber security attitudes,
-                  behaviours and expectations.
-                B6.a.9: People in your organisation raising potential cyber security
-                  incidents and issues are treated positively.
-                B6.a.10: Individuals at all levels in your organisation routinely
-                  report concerns or issues about cyber security and are recognised
-                  for their contribution to keeping the organisation secure.
-                B6.a.11: Your management is seen to be committed to and actively involved
-                  in cyber security.
-                B6.a.12: Your organisation communicates openly about cyber security,
-                  with any concern being taken seriously.
-                B6.a.13: People across your organisation participate in cyber security
-                  activities and improvements, building joint ownership and bringing
-                  knowledge of their area of expertise.
+                B6.a.8:
+                  description: Your executive management clearly and effectively communicates
+                    the organisation's cyber security priorities and objectives to
+                    all staff. Your organisation displays positive cyber security
+                    attitudes, behaviours and expectations.
+                B6.a.9:
+                  description: People in your organisation raising potential cyber
+                    security incidents and issues are treated positively.
+                B6.a.10:
+                  description: Individuals at all levels in your organisation routinely
+                    report concerns or issues about cyber security and are recognised
+                    for their contribution to keeping the organisation secure.
+                B6.a.11:
+                  description: Your management is seen to be committed to and actively
+                    involved in cyber security.
+                B6.a.12:
+                  description: Your organisation communicates openly about cyber security,
+                    with any concern being taken seriously.
+                B6.a.13:
+                  description: People across your organisation participate in cyber
+                    security activities and improvements, building joint ownership
+                    and bringing knowledge of their area of expertise.
             assessment-rules: *standard-rules
           B6.b:
             code: B6.b
@@ -1201,30 +1542,42 @@ objectives:
               cyber security training, awareness and communications are employed.
             indicators:
               not-achieved:
-                B6.b.1: There are teams who operate and support your essential function(s)
-                  that lack any cyber security training.
-                B6.b.2: Cyber security training is restricted to specific roles in
-                  your organisation.
-                B6.b.3: Cyber security training records for your organisation are
-                  lacking or incomplete.
+                B6.b.1:
+                  description: There are teams who operate and support your essential
+                    function(s) that lack any cyber security training.
+                B6.b.2:
+                  description: Cyber security training is restricted to specific roles
+                    in your organisation.
+                B6.b.3:
+                  description: Cyber security training records for your organisation
+                    are lacking or incomplete.
               partially-achieved:
-                B6.b.4: You have defined appropriate cyber security training and awareness
-                  activities for all roles in your organisation, from executives to
-                  the most junior roles.
-                B6.b.5: You use a range of teaching and communication techniques for
-                  cyber security training and awareness to reach the widest audience
-                  effectively.
-                B6.b.6: Cyber security information is easily available.
+                B6.b.4:
+                  description: You have defined appropriate cyber security training
+                    and awareness activities for all roles in your organisation, from
+                    executives to the most junior roles.
+                B6.b.5:
+                  description: You use a range of teaching and communication techniques
+                    for cyber security training and awareness to reach the widest
+                    audience effectively.
+                B6.b.6:
+                  description: Cyber security information is easily available.
               achieved:
-                B6.b.7: All people in your organisation, from the most senior to the
-                  most junior, follow appropriate cyber security training paths.
-                B6.b.8: Each individuals cyber security training is tracked and refreshed
-                  at suitable intervals.
-                B6.b.9: You routinely evaluate your cyber security training and awareness
-                  activities to ensure they reach the widest audience and are effective.
-                B6.b.10: You make cyber security information and good practice guidance
-                  easily accessible, widely available and you know it is referenced
-                  and used within your organisation.
+                B6.b.7:
+                  description: All people in your organisation, from the most senior
+                    to the most junior, follow appropriate cyber security training
+                    paths.
+                B6.b.8:
+                  description: Each individuals cyber security training is tracked
+                    and refreshed at suitable intervals.
+                B6.b.9:
+                  description: You routinely evaluate your cyber security training
+                    and awareness activities to ensure they reach the widest audience
+                    and are effective.
+                B6.b.10:
+                  description: You make cyber security information and good practice
+                    guidance easily accessible, widely available and you know it is
+                    referenced and used within your organisation.
             assessment-rules: *standard-rules
   C:
     code: C
@@ -1249,46 +1602,62 @@ objectives:
               operation of your essential function(s).
             indicators:
               not-achieved:
-                C1.a.1: Data relating to the security and operation of your essential
-                  function(s) is not collected.
-                C1.a.2: You do not confidently detect the presence or absence of Indicators
-                  of Compromise (IoCs) on your essential function(s), such as known
-                  malicious command and control signatures (e.g. because applying
-                  the indicator is difficult or your log data is not sufficiently
-                  detailed).
-                C1.a.3: You are not able to audit the activities of users in relation
-                  to your essential function(s).
-                C1.a.4: You do not capture any traffic crossing your network boundary
-                  including as a minimum IP connections.
+                C1.a.1:
+                  description: Data relating to the security and operation of your
+                    essential function(s) is not collected.
+                C1.a.2:
+                  description: You do not confidently detect the presence or absence
+                    of Indicators of Compromise (IoCs) on your essential function(s),
+                    such as known malicious command and control signatures (e.g. because
+                    applying the indicator is difficult or your log data is not sufficiently
+                    detailed).
+                C1.a.3:
+                  description: You are not able to audit the activities of users in
+                    relation to your essential function(s).
+                C1.a.4:
+                  description: You do not capture any traffic crossing your network
+                    boundary including as a minimum IP connections.
               partially-achieved:
-                C1.a.5: Data relating to the security and operation of some areas
-                  of your essential function(s) is collected but coverage is not comprehensive.
-                C1.a.6: You easily detect the presence or absence of IoCs on your
-                  essential function(s), such as known malicious command and control
-                  signatures.
-                C1.a.7: Some user monitoring is done, but not covering a fully agreed
-                  list of suspicious or undesirable behaviour.
-                C1.a.8: You monitor traffic crossing your network boundary (including
-                  IP address connections as a minimum).
+                C1.a.5:
+                  description: Data relating to the security and operation of some
+                    areas of your essential function(s) is collected but coverage
+                    is not comprehensive.
+                C1.a.6:
+                  description: You easily detect the presence or absence of IoCs on
+                    your essential function(s), such as known malicious command and
+                    control signatures.
+                C1.a.7:
+                  description: Some user monitoring is done, but not covering a fully
+                    agreed list of suspicious or undesirable behaviour.
+                C1.a.8:
+                  description: You monitor traffic crossing your network boundary
+                    (including IP address connections as a minimum).
               achieved:
-                C1.a.9: Monitoring is based on an understanding of your networks,
-                  common cyber attack methods and what you need awareness of in order
-                  to detect potential security incidents that could affect the operation
-                  of your essential function(s) (e.g. presence of malware, malicious
-                  emails, user policy violations).
-                C1.a.10: Your monitoring data provides enough detail to reliably detect
-                  security incidents that could affect the operation of your essential
-                  function(s).
-                C1.a.11: You easily detect the presence or absence of IoCs on your
-                  essential function(s), such as known malicious command and control
-                  signatures.
-                C1.a.12: Extensive monitoring of user activity in relation to the
-                  operation of your essential function(s) enables you to detect policy
-                  violations and an agreed list of suspicious or undesirable behaviour.
-                C1.a.13: You have extensive monitoring coverage that includes host-based
-                  monitoring and network gateways.
-                C1.a.14: All new systems are considered as potential monitoring data
-                  sources to maintain a comprehensive monitoring capability.
+                C1.a.9:
+                  description: Monitoring is based on an understanding of your networks,
+                    common cyber attack methods and what you need awareness of in
+                    order to detect potential security incidents that could affect
+                    the operation of your essential function(s) (e.g. presence of
+                    malware, malicious emails, user policy violations).
+                C1.a.10:
+                  description: Your monitoring data provides enough detail to reliably
+                    detect security incidents that could affect the operation of your
+                    essential function(s).
+                C1.a.11:
+                  description: You easily detect the presence or absence of IoCs on
+                    your essential function(s), such as known malicious command and
+                    control signatures.
+                C1.a.12:
+                  description: Extensive monitoring of user activity in relation to
+                    the operation of your essential function(s) enables you to detect
+                    policy violations and an agreed list of suspicious or undesirable
+                    behaviour.
+                C1.a.13:
+                  description: You have extensive monitoring coverage that includes
+                    host-based monitoring and network gateways.
+                C1.a.14:
+                  description: All new systems are considered as potential monitoring
+                    data sources to maintain a comprehensive monitoring capability.
             assessment-rules: *standard-rules
           C1.b:
             code: C1.b
@@ -1299,37 +1668,54 @@ objectives:
               period, after which it should be deleted.
             indicators:
               not-achieved:
-                C1.b.1: It is possible for log data to be easily edited or deleted
-                  by unauthorised users or malicious attackers.
-                C1.b.2: There is no controlled list of the users and systems that
-                  can view and query log data.
-                C1.b.3: There is no monitoring of the access to log data.
-                C1.b.4: There is no policy for accessing log data.
-                C1.b.5: Log data is not synchronised, using an accurate common time
-                  source.
+                C1.b.1:
+                  description: It is possible for log data to be easily edited or
+                    deleted by unauthorised users or malicious attackers.
+                C1.b.2:
+                  description: There is no controlled list of the users and systems
+                    that can view and query log data.
+                C1.b.3:
+                  description: There is no monitoring of the access to log data.
+                C1.b.4:
+                  description: There is no policy for accessing log data.
+                C1.b.5:
+                  description: Log data is not synchronised, using an accurate common
+                    time source.
               partially-achieved:
-                C1.b.6: Only authorised staff can view log data for investigations.
-                C1.b.7: Authorised users and systems can appropriately access log
-                  data.
-                C1.b.8: There is some monitoring of access to log data (e.g. copying,
-                  deleting, modifying or viewing).
+                C1.b.6:
+                  description: Only authorised staff can view log data for investigations.
+                C1.b.7:
+                  description: Authorised users and systems can appropriately access
+                    log data.
+                C1.b.8:
+                  description: There is some monitoring of access to log data (e.g.
+                    copying, deleting, modifying or viewing).
               achieved:
-                C1.b.9: The integrity of log data is protected, or any modification
-                  is detected and attributed.
-                C1.b.10: The logging architecture has mechanisms, policies, processes
-                  and procedures to ensure that it can protect itself from threats
-                  comparable to those it is trying to identify. This includes protecting
-                  the essential function(s) itself, and the data within it.
-                C1.b.11: Log data analysis and normalisation is only performed on
-                  copies of the data keeping the master copy unaltered.
-                C1.b.12: Log data is synchronised, using an accurate common time source,
-                  so that separate datasets can be correlated in different ways.
-                C1.b.13: Access to log data is limited to those with business need
-                  and no others.
-                C1.b.14: All actions involving all log data (e.g. copying, deleting,
-                  modifying or viewing) can be traced back to a unique user.
-                C1.b.15: Legitimate reasons for accessing log data are given in use
-                  policies.
+                C1.b.9:
+                  description: The integrity of log data is protected, or any modification
+                    is detected and attributed.
+                C1.b.10:
+                  description: The logging architecture has mechanisms, policies,
+                    processes and procedures to ensure that it can protect itself
+                    from threats comparable to those it is trying to identify. This
+                    includes protecting the essential function(s) itself, and the
+                    data within it.
+                C1.b.11:
+                  description: Log data analysis and normalisation is only performed
+                    on copies of the data keeping the master copy unaltered.
+                C1.b.12:
+                  description: Log data is synchronised, using an accurate common
+                    time source, so that separate datasets can be correlated in different
+                    ways.
+                C1.b.13:
+                  description: Access to log data is limited to those with business
+                    need and no others.
+                C1.b.14:
+                  description: All actions involving all log data (e.g. copying, deleting,
+                    modifying or viewing) can be traced back to a unique user.
+                C1.b.15:
+                  description: Legitimate reasons for accessing log data are given
+                    in use policies.
             assessment-rules: *standard-rules
           C1.c:
             code: C1.c
@@ -1338,39 +1724,56 @@ objectives:
               monitoring data is reliably identified and triggers alerts.
             indicators:
               not-achieved:
-                C1.c.1: Alerts from third party security software are not investigated
-                  (e.g. Anti-Virus (AV) providers).
-                C1.c.2: Logs are distributed across devices with no easy way to access
-                  them other than manual login or physical action.
-                C1.c.3: The resolution of alerts to a network asset or system is not
-                  performed.
-                C1.c.4: Security alerts relating to essential function(s) are not
-                  prioritised.
-                C1.c.5: Logs are reviewed infrequently.
+                C1.c.1:
+                  description: Alerts from third party security software are not investigated
+                    (e.g. Anti-Virus (AV) providers).
+                C1.c.2:
+                  description: Logs are distributed across devices with no easy way
+                    to access them other than manual login or physical action.
+                C1.c.3:
+                  description: The resolution of alerts to a network asset or system
+                    is not performed.
+                C1.c.4:
+                  description: Security alerts relating to essential function(s) are
+                    not prioritised.
+                C1.c.5:
+                  description: Logs are reviewed infrequently.
               partially-achieved:
-                C1.c.6: Alerts from third party security software are investigated,
-                  and action taken.
-                C1.c.7: Some, but not all, log data can be easily queried with search
-                  tools to aid investigations.
-                C1.c.8: The resolution of alerts to a network asset or system is performed
-                  regularly.
-                C1.c.9: Security alerts relating to some essential function(s) are
-                  prioritised.
-                C1.c.10: Logs are reviewed at regular intervals.
+                C1.c.6:
+                  description: Alerts from third party security software are investigated,
+                    and action taken.
+                C1.c.7:
+                  description: Some, but not all, log data can be easily queried with
+                    search tools to aid investigations.
+                C1.c.8:
+                  description: The resolution of alerts to a network asset or system
+                    is performed regularly.
+                C1.c.9:
+                  description: Security alerts relating to some essential function(s)
+                    are prioritised.
+                C1.c.10:
+                  description: Logs are reviewed at regular intervals.
               achieved:
-                C1.c.11: Log data is enriched with other network knowledge and data
-                  when investigating certain suspicious activity or alerts.
-                C1.c.12: A wide range of signatures and indicators of compromise is
-                  used for investigations of suspicious activity and alerts.
-                C1.c.13: Alerts can be easily resolved to network assets using knowledge
-                  of networks and systems. The resolution of these alerts is performed
-                  in almost real time.
-                C1.c.14: Security alerts relating to all essential function(s) are
-                  prioritised and this information is used to support incident management.
-                C1.c.15: Logs are reviewed almost continuously, in real time.
-                C1.c.16: Alerts are tested to ensure that they are generated reliably
-                  and that it is possible to distinguish genuine security incidents
-                  from false alarms.
+                C1.c.11:
+                  description: Log data is enriched with other network knowledge and
+                    data when investigating certain suspicious activity or alerts.
+                C1.c.12:
+                  description: A wide range of signatures and indicators of compromise
+                    is used for investigations of suspicious activity and alerts.
+                C1.c.13:
+                  description: Alerts can be easily resolved to network assets using
+                    knowledge of networks and systems. The resolution of these alerts
+                    is performed in almost real time.
+                C1.c.14:
+                  description: Security alerts relating to all essential function(s)
+                    are prioritised and this information is used to support incident
+                    management.
+                C1.c.15:
+                  description: Logs are reviewed almost continuously, in real time.
+                C1.c.16:
+                  description: Alerts are tested to ensure that they are generated
+                    reliably and that it is possible to distinguish genuine security
+                    incidents from false alarms.
             assessment-rules: *standard-rules
           C1.d:
             code: C1.d
@@ -1380,39 +1783,53 @@ objectives:
               form of response.
             indicators:
               not-achieved:
-                C1.d.1: Your organisation has no sources of threat intelligence.
-                C1.d.2: You do not apply updates in a timely way, after receiving
-                  them (e.g. AV signature updates, other threat signatures or Indicators
-                  of Compromise (IoCs)).
-                C1.d.3: You do not receive signature updates for all protective technologies
-                  such as AV and IDS or other software in use.
-                C1.d.4: You do not evaluate the usefulness of your threat intelligence
-                  or share feedback with providers or other users.
+                C1.d.1:
+                  description: Your organisation has no sources of threat intelligence.
+                C1.d.2:
+                  description: You do not apply updates in a timely way, after receiving
+                    them (e.g. AV signature updates, other threat signatures or Indicators
+                    of Compromise (IoCs)).
+                C1.d.3:
+                  description: You do not receive signature updates for all protective
+                    technologies such as AV and IDS or other software in use.
+                C1.d.4:
+                  description: You do not evaluate the usefulness of your threat intelligence
+                    or share feedback with providers or other users.
               partially-achieved:
-                C1.d.5: Your organisation uses some threat intelligence services,
-                  but you don't necessarily choose sources or providers specifically
-                  because of your business needs, or specific threats in your sector
-                  (e.g. sector-based infoshare, ICS software vendors, anti-virus providers,
-                  specialist threat intel firms, special interest groups).
-                C1.d.6: You receive updates for all your signature based protective
-                  technologies (e.g. AV, IDS).
-                C1.d.7: You apply some updates, signatures and IoCs in a timely way.
-                C1.d.8: You know how effective your threat intelligence is (e.g. by
-                  tracking how threat intelligence helps you identify security problems).
+                C1.d.5:
+                  description: Your organisation uses some threat intelligence services,
+                    but you don't necessarily choose sources or providers specifically
+                    because of your business needs, or specific threats in your sector
+                    (e.g. sector-based infoshare, ICS software vendors, anti-virus
+                    providers, specialist threat intel firms, special interest groups).
+                C1.d.6:
+                  description: You receive updates for all your signature based protective
+                    technologies (e.g. AV, IDS).
+                C1.d.7:
+                  description: You apply some updates, signatures and IoCs in a timely
+                    way.
+                C1.d.8:
+                  description: You know how effective your threat intelligence is
+                    (e.g. by tracking how threat intelligence helps you identify security
+                    problems).
               achieved:
-                C1.d.9: You have selected threat intelligence sources or services
-                  using risk-based and threat- informed decisions based on your business
-                  needs and sector (e.g. vendor reporting and patching, strong anti-virus
-                  providers, sector and community-based infoshare, special interest
-                  groups).
-                C1.d.10: You apply all new signatures and IoCs within a reasonable
-                  (risk-based) time of receiving them.
-                C1.d.11: You receive signature updates for all your protective technologies
-                  (e.g. AV, IDS).
-                C1.d.12: You track the effectiveness of your intelligence feeds and
-                  actively share feedback on the usefulness of IoCs and any other
-                  indicators with the threat community (e.g. sector partners, threat
-                  intelligence providers, government agencies).
+                C1.d.9:
+                  description: You have selected threat intelligence sources or services
+                    using risk-based and threat- informed decisions based on your
+                    business needs and sector (e.g. vendor reporting and patching,
+                    strong anti-virus providers, sector and community-based infoshare,
+                    special interest groups).
+                C1.d.10:
+                  description: You apply all new signatures and IoCs within a reasonable
+                    (risk-based) time of receiving them.
+                C1.d.11:
+                  description: You receive signature updates for all your protective
+                    technologies (e.g. AV, IDS).
+                C1.d.12:
+                  description: You track the effectiveness of your intelligence feeds
+                    and actively share feedback on the usefulness of IoCs and any
+                    other indicators with the threat community (e.g. sector partners,
+                    threat intelligence providers, government agencies).
             assessment-rules: *standard-rules
           C1.e:
             code: C1.e
@@ -1424,52 +1841,74 @@ objectives:
               they need to protect.
             indicators:
               not-achieved:
-                C1.e.1: There are no staff who perform a monitoring function.
-                C1.e.2: Monitoring staff do not have the correct specialist skills.
-                C1.e.3: Monitoring staff are not capable of reporting against governance
-                  requirements.
-                C1.e.4: Monitoring staff lack the skills to successfully perform some
-                  significant parts of the defined workflow.
-                C1.e.5: Monitoring tools are only able to make use of a fraction of
-                  log data being collected.
-                C1.e.6: Monitoring tools cannot be configured to make use of new logging
-                  streams, as they come online.
-                C1.e.7: Monitoring staff have a lack of awareness of the essential
-                  function(s) the organisation provides, what assets relate to those
-                  functions and hence the importance of the log data and security
-                  events.
+                C1.e.1:
+                  description: There are no staff who perform a monitoring function.
+                C1.e.2:
+                  description: Monitoring staff do not have the correct specialist
+                    skills.
+                C1.e.3:
+                  description: Monitoring staff are not capable of reporting against
+                    governance requirements.
+                C1.e.4:
+                  description: Monitoring staff lack the skills to successfully perform
+                    some significant parts of the defined workflow.
+                C1.e.5:
+                  description: Monitoring tools are only able to make use of a fraction
+                    of log data being collected.
+                C1.e.6:
+                  description: Monitoring tools cannot be configured to make use of
+                    new logging streams, as they come online.
+                C1.e.7:
+                  description: Monitoring staff have a lack of awareness of the essential
+                    function(s) the organisation provides, what assets relate to those
+                    functions and hence the importance of the log data and security
+                    events.
               partially-achieved:
-                C1.e.8: Monitoring staff have some investigative skills and a basic
-                  understanding of the data they need to work with.
-                C1.e.9: Monitoring staff can report to other parts of the organisation
-                  (e.g. security directors, resilience managers).
-                C1.e.10: Monitoring staff are capable of following most of the required
-                  workflows.
-                C1.e.11: Your monitoring tools can make use of logging that would
-                  capture most unsophisticated and untargeted attack types.
-                C1.e.12: Your monitoring tools work with most log data, with some
-                  configuration.
-                C1.e.13: Monitoring staff are aware of some essential function(s)
-                  and can manage alerts relating to them.
+                C1.e.8:
+                  description: Monitoring staff have some investigative skills and
+                    a basic understanding of the data they need to work with.
+                C1.e.9:
+                  description: Monitoring staff can report to other parts of the organisation
+                    (e.g. security directors, resilience managers).
+                C1.e.10:
+                  description: Monitoring staff are capable of following most of the
+                    required workflows.
+                C1.e.11:
+                  description: Your monitoring tools can make use of logging that
+                    would capture most unsophisticated and untargeted attack types.
+                C1.e.12:
+                  description: Your monitoring tools work with most log data, with
+                    some configuration.
+                C1.e.13:
+                  description: Monitoring staff are aware of some essential function(s)
+                    and can manage alerts relating to them.
               achieved:
-                C1.e.14: You have monitoring staff, who are responsible for the analysis,
-                  investigation and reporting of monitoring alerts covering both security
-                  and performance.
-                C1.e.15: Monitoring staff have defined roles and skills that cover
-                  all parts of the monitoring and investigation process.
-                C1.e.16: Monitoring staff follow policies, processes and procedures
-                  that address all governance reporting requirements, internal and
-                  external.
-                C1.e.17: Monitoring staff are empowered to look beyond the fixed process
-                  to investigate and understand non-standard threats, by developing
-                  their own investigative techniques and making new use of data.
-                C1.e.18: Your monitoring tools make use of all log data collected
-                  to pinpoint activity within an incident.
-                C1.e.19: Monitoring staff and tools drive and shape new log data collection
-                  and can make wide use of it.
-                C1.e.20: Monitoring staff are aware of the operation of essential
-                  function(s) and related assets and can identify and prioritise alerts
-                  or investigations that relate to them.
+                C1.e.14:
+                  description: You have monitoring staff, who are responsible for
+                    the analysis, investigation and reporting of monitoring alerts
+                    covering both security and performance.
+                C1.e.15:
+                  description: Monitoring staff have defined roles and skills that
+                    cover all parts of the monitoring and investigation process.
+                C1.e.16:
+                  description: Monitoring staff follow policies, processes and procedures
+                    that address all governance reporting requirements, internal and
+                    external.
+                C1.e.17:
+                  description: Monitoring staff are empowered to look beyond the fixed
+                    process to investigate and understand non-standard threats, by
+                    developing their own investigative techniques and making new use
+                    of data.
+                C1.e.18:
+                  description: Your monitoring tools make use of all log data collected
+                    to pinpoint activity within an incident.
+                C1.e.19:
+                  description: Monitoring staff and tools drive and shape new log
+                    data collection and can make wide use of it.
+                C1.e.20:
+                  description: Monitoring staff are aware of the operation of essential
+                    function(s) and related assets and can identify and prioritise
+                    alerts or investigations that relate to them.
             assessment-rules: *standard-rules
       C2:
         code: C2
@@ -1489,24 +1928,31 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                C2.a.1: Normal system behaviour is insufficiently understood to be
-                  able to use system abnormalities to detect malicious activity.
-                C2.a.2: You have no established understanding of what abnormalities
-                  to look for that might signify malicious activities.
+                C2.a.1:
+                  description: Normal system behaviour is insufficiently understood
+                    to be able to use system abnormalities to detect malicious activity.
+                C2.a.2:
+                  description: You have no established understanding of what abnormalities
+                    to look for that might signify malicious activities.
               achieved:
-                C2.a.3: Normal system behaviour is fully understood to such an extent
-                  that searching for system abnormalities is a potentially effective
-                  way of detecting malicious activity (e.g. You fully understand which
-                  systems should and should not communicate and when).
-                C2.a.4: System abnormality descriptions from past attacks and threat
-                  intelligence, on yours and other networks, are used to signify malicious
-                  activity.
-                C2.a.5: The system abnormalities you search for consider the nature
-                  of attacks likely to impact on the network and information systems
-                  supporting the operation of your essential function(s).
-                C2.a.6: The system abnormality descriptions you use are updated to
-                  reflect changes in your network and information systems and current
-                  threat intelligence.
+                C2.a.3:
+                  description: Normal system behaviour is fully understood to such
+                    an extent that searching for system abnormalities is a potentially
+                    effective way of detecting malicious activity (e.g. You fully
+                    understand which systems should and should not communicate and
+                    when).
+                C2.a.4:
+                  description: System abnormality descriptions from past attacks and
+                    threat intelligence, on yours and other networks, are used to
+                    signify malicious activity.
+                C2.a.5:
+                  description: The system abnormalities you search for consider the
+                    nature of attacks likely to impact on the network and information
+                    systems supporting the operation of your essential function(s).
+                C2.a.6:
+                  description: The system abnormality descriptions you use are updated
+                    to reflect changes in your network and information systems and
+                    current threat intelligence.
             assessment-rules: *standard-rules
           C2.b:
             code: C2.b
@@ -1517,15 +1963,19 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                C2.b.1: You do not routinely search for system abnormalities indicative
-                  of malicious activity.
+                C2.b.1:
+                  description: You do not routinely search for system abnormalities
+                    indicative of malicious activity.
               achieved:
-                C2.b.2: You routinely search for system abnormalities indicative of
-                  malicious activity on the network and information systems supporting
-                  the operation of your essential function(s), generating alerts based
-                  on the results of such searches.
-                C2.b.3: You have justified confidence in the effectiveness of your
-                  searches for system abnormalities indicative of malicious activity.
+                C2.b.2:
+                  description: You routinely search for system abnormalities indicative
+                    of malicious activity on the network and information systems supporting
+                    the operation of your essential function(s), generating alerts
+                    based on the results of such searches.
+                C2.b.3:
+                  description: You have justified confidence in the effectiveness
+                    of your searches for system abnormalities indicative of malicious
+                    activity.
             assessment-rules: *standard-rules
   D:
     code: D
@@ -1550,35 +2000,46 @@ objectives:
               and covers a range of incident scenarios.
             indicators:
               not-achieved:
-                D1.a.1: Your incident response plan is not documented.
-                D1.a.2: Your incident response plan does not include your organisations
-                  identified essential function(s).
-                D1.a.3: Your incident response plan is not well understood by relevant
-                  staff.
+                D1.a.1:
+                  description: Your incident response plan is not documented.
+                D1.a.2:
+                  description: Your incident response plan does not include your organisations
+                    identified essential function(s).
+                D1.a.3:
+                  description: Your incident response plan is not well understood
+                    by relevant staff.
               partially-achieved:
-                D1.a.4: Your incident response plan covers your essential function(s).
-                D1.a.5: Your incident response plan comprehensively covers scenarios
-                  that are focused on likely impacts of known and well understood
-                  attacks only.
-                D1.a.6: Your incident response plan is understood by all staff who
-                  are involved with your organisation's response function.
-                D1.a.7: Your incident response plan is documented and shared with
-                  all relevant stakeholders.
+                D1.a.4:
+                  description: Your incident response plan covers your essential function(s).
+                D1.a.5:
+                  description: Your incident response plan comprehensively covers
+                    scenarios that are focused on likely impacts of known and well
+                    understood attacks only.
+                D1.a.6:
+                  description: Your incident response plan is understood by all staff
+                    who are involved with your organisation's response function.
+                D1.a.7:
+                  description: Your incident response plan is documented and shared
+                    with all relevant stakeholders.
               achieved:
-                D1.a.8: Your incident response plan is based on a clear understanding
-                  of the security risks to the network and information systems supporting
-                  your essential function(s).
-                D1.a.9: Your incident response plan is comprehensive (i.e. covers
-                  the complete lifecycle of an incident, roles and responsibilities,
-                  and reporting) and covers likely impacts of both known attack patterns
-                  and of possible attacks, previously unseen.
-                D1.a.10: Your incident response plan is documented and integrated
-                  with wider organisational business plans and supply chain response
-                  plans, as well as dependencies on supporting infrastructure (e.g.
-                  power, cooling etc).
-                D1.a.11: Your incident response plan is communicated and understood
-                  by the business areas involved with the operation of your essential
-                  function(s).
+                D1.a.8:
+                  description: Your incident response plan is based on a clear understanding
+                    of the security risks to the network and information systems supporting
+                    your essential function(s).
+                D1.a.9:
+                  description: Your incident response plan is comprehensive (i.e.
+                    covers the complete lifecycle of an incident, roles and responsibilities,
+                    and reporting) and covers likely impacts of both known attack
+                    patterns and of possible attacks, previously unseen.
+                D1.a.10:
+                  description: Your incident response plan is documented and integrated
+                    with wider organisational business plans and supply chain response
+                    plans, as well as dependencies on supporting infrastructure (e.g.
+                    power, cooling etc).
+                D1.a.11:
+                  description: Your incident response plan is communicated and understood
+                    by the business areas involved with the operation of your essential
+                    function(s).
             assessment-rules: *standard-rules
           D1.b:
             code: D1.b
@@ -1590,32 +2051,41 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                D1.b.1: Inadequate arrangements have been made to make the right resources
-                  available to implement your response plan.
-                D1.b.2: Your response team members are not equipped to make good response
-                  decisions and put them into effect.
-                D1.b.3: Inadequate back-up mechanisms exist to allow the continued
-                  operation of your essential function(s) during an incident.
+                D1.b.1:
+                  description: Inadequate arrangements have been made to make the
+                    right resources available to implement your response plan.
+                D1.b.2:
+                  description: Your response team members are not equipped to make
+                    good response decisions and put them into effect.
+                D1.b.3:
+                  description: Inadequate back-up mechanisms exist to allow the continued
+                    operation of your essential function(s) during an incident.
               achieved:
-                D1.b.4: You understand the resources that will likely be needed to
-                  carry out any required response activities, and arrangements are
-                  in place to make these resources available.
-                D1.b.5: You understand the types of information that will likely be
-                  needed to inform response decisions and arrangements are in place
-                  to make this information available.
-                D1.b.6: Your response team members have the skills and knowledge required
-                  to decide on the response actions necessary to limit harm, and the
-                  authority to carry them out.
-                D1.b.7: Key roles are duplicated, and operational delivery knowledge
-                  is shared with all individuals involved in the operations and recovery
-                  of the essential function(s).
-                D1.b.8: Back-up mechanisms are available that can be readily activated
-                  to allow continued operation of your essential function(s), although
-                  possibly at a reduced level, if primary network and information
-                  systems fail or are unavailable.
-                D1.b.9: Arrangements exist to augment your organisation's incident
-                  response capabilities with external support if necessary (e.g. specialist
-                  cyber incident responders).
+                D1.b.4:
+                  description: You understand the resources that will likely be needed
+                    to carry out any required response activities, and arrangements
+                    are in place to make these resources available.
+                D1.b.5:
+                  description: You understand the types of information that will likely
+                    be needed to inform response decisions and arrangements are in
+                    place to make this information available.
+                D1.b.6:
+                  description: Your response team members have the skills and knowledge
+                    required to decide on the response actions necessary to limit
+                    harm, and the authority to carry them out.
+                D1.b.7:
+                  description: Key roles are duplicated, and operational delivery
+                    knowledge is shared with all individuals involved in the operations
+                    and recovery of the essential function(s).
+                D1.b.8:
+                  description: Back-up mechanisms are available that can be readily
+                    activated to allow continued operation of your essential function(s),
+                    although possibly at a reduced level, if primary network and information
+                    systems fail or are unavailable.
+                D1.b.9:
+                  description: Arrangements exist to augment your organisation's incident
+                    response capabilities with external support if necessary (e.g.
+                    specialist cyber incident responders).
             assessment-rules: *standard-rules
           D1.c:
             code: D1.c
@@ -1626,25 +2096,33 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                D1.c.1: Exercises test only a discrete part of the process (e.g. that
-                  backups are working), but do not consider all areas.
-                D1.c.2: Incident response exercises are not routinely carried out
-                  or are carried out in an ad-hoc way.
-                D1.c.3: Outputs from exercises are not fed into the organisation's
-                  lessons learned process.
-                D1.c.4: Exercises do not test all parts of the response cycle.
+                D1.c.1:
+                  description: Exercises test only a discrete part of the process
+                    (e.g. that backups are working), but do not consider all areas.
+                D1.c.2:
+                  description: Incident response exercises are not routinely carried
+                    out or are carried out in an ad-hoc way.
+                D1.c.3:
+                  description: Outputs from exercises are not fed into the organisation's
+                    lessons learned process.
+                D1.c.4:
+                  description: Exercises do not test all parts of the response cycle.
               achieved:
-                D1.c.5: Exercise scenarios are based on incidents experienced by your
-                  and other organisations or are composed using experience or threat
-                  intelligence.
-                D1.c.6: Exercise scenarios are documented, regularly reviewed, and
-                  validated.
-                D1.c.7: Exercises are routinely run, with the findings documented
-                  and used to refine incident response plans and protective security,
-                  in line with the lessons learned.
-                D1.c.8: Exercises test all parts of your response cycle relating to
-                  your essential function(s) (e.g. restoration of normal function(s)
-                  levels).
+                D1.c.5:
+                  description: Exercise scenarios are based on incidents experienced
+                    by your and other organisations or are composed using experience
+                    or threat intelligence.
+                D1.c.6:
+                  description: Exercise scenarios are documented, regularly reviewed,
+                    and validated.
+                D1.c.7:
+                  description: Exercises are routinely run, with the findings documented
+                    and used to refine incident response plans and protective security,
+                    in line with the lessons learned.
+                D1.c.8:
+                  description: Exercises test all parts of your response cycle relating
+                    to your essential function(s) (e.g. restoration of normal function(s)
+                    levels).
             assessment-rules: *standard-rules
       D2:
         code: D2
@@ -1661,16 +2139,23 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                D2.a.1: You are not usually able to resolve incidents to a root cause.
-                D2.a.2: You do not have a formal process for investigating causes.
+                D2.a.1:
+                  description: You are not usually able to resolve incidents to a
+                    root cause.
+                D2.a.2:
+                  description: You do not have a formal process for investigating
+                    causes.
               achieved:
-                D2.a.3: Root cause analysis is conducted routinely as a key part of
-                  your lessons learned activities following an incident.
-                D2.a.4: Your root cause analysis is comprehensive, covering organisational
-                  process issues, as well as vulnerabilities in your networks, systems
-                  or software.
-                D2.a.5: All relevant incident data is made available to the analysis
-                  team to perform root cause analysis.
+                D2.a.3:
+                  description: Root cause analysis is conducted routinely as a key
+                    part of your lessons learned activities following an incident.
+                D2.a.4:
+                  description: Your root cause analysis is comprehensive, covering
+                    organisational process issues, as well as vulnerabilities in your
+                    networks, systems or software.
+                D2.a.5:
+                  description: All relevant incident data is made available to the
+                    analysis team to perform root cause analysis.
             assessment-rules: *standard-rules
           D2.b:
             code: D2.b
@@ -1680,22 +2165,30 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                D2.b.1: Following incidents, lessons learned are not captured or are
-                  limited in scope.
-                D2.b.2: Improvements arising from lessons learned following an incident
-                  are not implemented or not given sufficient organisational priority.
+                D2.b.1:
+                  description: Following incidents, lessons learned are not captured
+                    or are limited in scope.
+                D2.b.2:
+                  description: Improvements arising from lessons learned following
+                    an incident are not implemented or not given sufficient organisational
+                    priority.
               achieved:
-                D2.b.3: You have a documented incident review process/policy which
-                  ensures that lessons learned from each incident are identified,
-                  captured, and acted upon.
-                D2.b.4: Lessons learned cover issues with reporting, roles, governance,
-                  skills and organisational processes as well as technical aspects
-                  of network and information systems.
-                D2.b.5: You use lessons learned to improve security measures, including
-                  updating and retesting response plans when necessary.
-                D2.b.6: Security improvements identified as a result of lessons learned
-                  are prioritised, with the highest priority improvements completed
-                  quickly.
-                D2.b.7: Analysis is fed to senior management and incorporated into
-                  risk management and continuous improvement.
+                D2.b.3:
+                  description: You have a documented incident review process/policy
+                    which ensures that lessons learned from each incident are identified,
+                    captured, and acted upon.
+                D2.b.4:
+                  description: Lessons learned cover issues with reporting, roles,
+                    governance, skills and organisational processes as well as technical
+                    aspects of network and information systems.
+                D2.b.5:
+                  description: You use lessons learned to improve security measures,
+                    including updating and retesting response plans when necessary.
+                D2.b.6:
+                  description: Security improvements identified as a result of lessons
+                    learned are prioritised, with the highest priority improvements
+                    completed quickly.
+                D2.b.7:
+                  description: Analysis is fed to senior management and incorporated
+                    into risk management and continuous improvement.
             assessment-rules: *standard-rules

--- a/tests/fixtures/caf-v3.2-dummy.yaml
+++ b/tests/fixtures/caf-v3.2-dummy.yaml
@@ -8,7 +8,6 @@ assessment-rules: &standard-rules
   3:
   - not-achieved
   - any
-
 objectives:
   A:
     code: A
@@ -28,23 +27,41 @@ objectives:
             scope: system
             indicators:
               not-achieved:
-                A1.a.1: Security operation data is not collected.
-                A1.a.2: You cannot detect the presence of IoCs on essential functions.
-                A1.a.3: User activity auditing is not possible.
-                A1.a.4: Network boundary traffic is not captured.
+                A1.a.1:
+                  description: Security operation data is not collected.
+                A1.a.2:
+                  description: You cannot detect the presence of IoCs on essential
+                    functions.
+                A1.a.3:
+                  description: User activity auditing is not possible.
+                A1.a.4:
+                  description: Network boundary traffic is not captured.
               partially-achieved:
-                A1.a.5: Some security data is collected but coverage is not comprehensive.
-                A1.a.6: IoCs can be detected on essential functions.
-                A1.a.7: Limited user monitoring is performed.
-                A1.a.8: Basic network traffic monitoring is in place.
+                A1.a.5:
+                  description: Some security data is collected but coverage is not
+                    comprehensive.
+                A1.a.6:
+                  description: IoCs can be detected on essential functions.
+                A1.a.7:
+                  description: Limited user monitoring is performed.
+                A1.a.8:
+                  description: Basic network traffic monitoring is in place.
               achieved:
-                A1.a.9: Monitoring is based on understanding of networks and attack
-                  methods.
-                A1.a.10: Monitoring data is detailed enough to detect security incidents.
-                A1.a.11: IoC detection is effective and reliable.
-                A1.a.12: User activity monitoring detects policy violations.
-                A1.a.13: Monitoring includes host-based and network gateway coverage.
-                A1.a.14: New systems are evaluated as monitoring data sources.
+                A1.a.9:
+                  description: Monitoring is based on understanding of networks and
+                    attack methods.
+                A1.a.10:
+                  description: Monitoring data is detailed enough to detect security
+                    incidents.
+                A1.a.11:
+                  description: IoC detection is effective and reliable.
+                A1.a.12:
+                  description: User activity monitoring detects policy violations.
+                A1.a.13:
+                  description: Monitoring includes host-based and network gateway
+                    coverage.
+                A1.a.14:
+                  description: New systems are evaluated as monitoring data sources.
             assessment-rules: *standard-rules
       A2:
         code: A2
@@ -60,14 +77,22 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A2.a.1: Normal system behavior is not understood for abnormality detection.
-                A2.a.2: No framework exists for identifying suspicious abnormalities.
+                A2.a.1:
+                  description: Normal system behavior is not understood for abnormality
+                    detection.
+                A2.a.2:
+                  description: No framework exists for identifying suspicious abnormalities.
               achieved:
-                A2.a.3: Normal system behavior is well understood for effective detection.
-                A2.a.4: Past attack patterns inform abnormality detection.
-                A2.a.5: Detection considers likely attack scenarios for essential
-                  systems.
-                A2.a.6: Abnormality definitions are regularly updated.
+                A2.a.3:
+                  description: Normal system behavior is well understood for effective
+                    detection.
+                A2.a.4:
+                  description: Past attack patterns inform abnormality detection.
+                A2.a.5:
+                  description: Detection considers likely attack scenarios for essential
+                    systems.
+                A2.a.6:
+                  description: Abnormality definitions are regularly updated.
             assessment-rules: *standard-rules
           A2.b:
             code: A2.b
@@ -77,10 +102,15 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                A2.b.1: No routine searching for system abnormalities occurs.
+                A2.b.1:
+                  description: No routine searching for system abnormalities occurs.
               achieved:
-                A2.b.2: Regular searches for abnormalities generate actionable alerts.
-                A2.b.3: Confidence in abnormality detection effectiveness is justified.
+                A2.b.2:
+                  description: Regular searches for abnormalities generate actionable
+                    alerts.
+                A2.b.3:
+                  description: Confidence in abnormality detection effectiveness is
+                    justified.
             assessment-rules: *standard-rules
   B:
     code: B
@@ -99,19 +129,32 @@ objectives:
             scope: system
             indicators:
               not-achieved:
-                B1.a.1: Response plan is not documented.
-                B1.a.2: Response plan omits essential functions.
-                B1.a.3: Staff do not understand the response plan.
+                B1.a.1:
+                  description: Response plan is not documented.
+                B1.a.2:
+                  description: Response plan omits essential functions.
+                B1.a.3:
+                  description: Staff do not understand the response plan.
               partially-achieved:
-                B1.a.4: Response plan includes essential functions.
-                B1.a.5: Plan covers known attack scenarios only.
-                B1.a.6: Response team understands the plan.
-                B1.a.7: Plan is documented and shared with stakeholders.
+                B1.a.4:
+                  description: Response plan includes essential functions.
+                B1.a.5:
+                  description: Plan covers known attack scenarios only.
+                B1.a.6:
+                  description: Response team understands the plan.
+                B1.a.7:
+                  description: Plan is documented and shared with stakeholders.
               achieved:
-                B1.a.8: Plan is based on security risk understanding.
-                B1.a.9: Plan comprehensively covers incident lifecycle and scenarios.
-                B1.a.10: Plan integrates with organizational and supply chain plans.
-                B1.a.11: Plan is understood by all relevant business areas.
+                B1.a.8:
+                  description: Plan is based on security risk understanding.
+                B1.a.9:
+                  description: Plan comprehensively covers incident lifecycle and
+                    scenarios.
+                B1.a.10:
+                  description: Plan integrates with organizational and supply chain
+                    plans.
+                B1.a.11:
+                  description: Plan is understood by all relevant business areas.
             assessment-rules: *standard-rules
           B1.b:
             code: B1.b
@@ -121,16 +164,25 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                B1.b.1: Resource planning for response is inadequate.
-                B1.b.2: Response team lacks necessary skills and authority.
-                B1.b.3: Backup mechanisms for operations are insufficient.
+                B1.b.1:
+                  description: Resource planning for response is inadequate.
+                B1.b.2:
+                  description: Response team lacks necessary skills and authority.
+                B1.b.3:
+                  description: Backup mechanisms for operations are insufficient.
               achieved:
-                B1.b.4: Resource requirements are understood and available.
-                B1.b.5: Information needs for response decisions are planned.
-                B1.b.6: Response team has skills and authority to act.
-                B1.b.7: Key roles have redundancy and knowledge is shared.
-                B1.b.8: Backup mechanisms support continued operations.
-                B1.b.9: External support arrangements exist if needed.
+                B1.b.4:
+                  description: Resource requirements are understood and available.
+                B1.b.5:
+                  description: Information needs for response decisions are planned.
+                B1.b.6:
+                  description: Response team has skills and authority to act.
+                B1.b.7:
+                  description: Key roles have redundancy and knowledge is shared.
+                B1.b.8:
+                  description: Backup mechanisms support continued operations.
+                B1.b.9:
+                  description: External support arrangements exist if needed.
             assessment-rules: *standard-rules
           B1.c:
             code: B1.c
@@ -140,15 +192,24 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                B1.c.1: Testing covers only limited parts of the process.
-                B1.c.2: Response exercises are infrequent or ad-hoc.
-                B1.c.3: Exercise outputs aren't used for improvement.
-                B1.c.4: Testing doesn't cover full response cycle.
+                B1.c.1:
+                  description: Testing covers only limited parts of the process.
+                B1.c.2:
+                  description: Response exercises are infrequent or ad-hoc.
+                B1.c.3:
+                  description: Exercise outputs aren't used for improvement.
+                B1.c.4:
+                  description: Testing doesn't cover full response cycle.
               achieved:
-                B1.c.5: Scenarios are based on actual incidents and threat intelligence.
-                B1.c.6: Exercise scenarios are documented and regularly reviewed.
-                B1.c.7: Regular exercises improve response plans and security.
-                B1.c.8: Testing covers the entire response cycle.
+                B1.c.5:
+                  description: Scenarios are based on actual incidents and threat
+                    intelligence.
+                B1.c.6:
+                  description: Exercise scenarios are documented and regularly reviewed.
+                B1.c.7:
+                  description: Regular exercises improve response plans and security.
+                B1.c.8:
+                  description: Testing covers the entire response cycle.
             assessment-rules: *standard-rules
       B2:
         code: B2
@@ -163,10 +224,15 @@ objectives:
             indicators:
               partially-achieved: {}
               not-achieved:
-                B2.a.1: Incidents cannot be resolved to root cause.
-                B2.a.2: No formal cause investigation process exists.
+                B2.a.1:
+                  description: Incidents cannot be resolved to root cause.
+                B2.a.2:
+                  description: No formal cause investigation process exists.
               achieved:
-                B2.a.3: Root cause analysis is routine after incidents.
-                B2.a.4: Analysis covers process issues and technical vulnerabilities.
-                B2.a.5: All relevant data is available to the analysis team.
+                B2.a.3:
+                  description: Root cause analysis is routine after incidents.
+                B2.a.4:
+                  description: Analysis covers process issues and technical vulnerabilities.
+                B2.a.5:
+                  description: All relevant data is available to the analysis team.
             assessment-rules: *standard-rules

--- a/webcaf/webcaf/caf32_field_providers.py
+++ b/webcaf/webcaf/caf32_field_providers.py
@@ -45,7 +45,7 @@ class OutcomeIndicatorsFieldProvider(FieldProvider):
                     fields.append(
                         {
                             "name": f"{level}_{indicator_id}",
-                            "label": indicator_text,
+                            "label": indicator_text["description"],
                             "type": "boolean",
                             "required": False,
                         }


### PR DESCRIPTION
So that we can merge in the contents of another YAML file with metadata about each indicator. This might be useful for fine-tuning how the forms are rendered but more usefully will allow us to add information needed for indicator-level validations.