### PR TITLE
Feature/use checkbox in indicator screens

### DIFF
--- a/.hooks/mypy-wrapper.sh
+++ b/.hooks/mypy-wrapper.sh
@@ -2,5 +2,6 @@
 #Wrapper file to pass the environment variables for the mypy pre-commit command
 
 export SSO_MODE=none
+export DEBUG=True
 
 exec mypy "$@"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,3 +56,4 @@ repos:
           - mozilla_django_oidc
           - django-multiselectfield
           - openpyxl
+          - python-dotenv

--- a/tests/test_caf32_field_providers.py
+++ b/tests/test_caf32_field_providers.py
@@ -32,14 +32,15 @@ class FormProvidersTestCase(TestCase):
         provider = OutcomeIndicatorsFieldProvider(self.outcome_data)
         fields = provider.get_field_definitions()
         self.assertIsInstance(fields, list)
-        self.assertEqual(len(fields), 14)
+        self.assertEqual(len(fields), 18)
         for field in fields:
             self.assertIn("name", field)
             self.assertIn("label", field)
             self.assertIn("type", field)
             self.assertIn("required", field)
-            self.assertEqual(field["type"], "choice_with_justifications")
-            self.assertTrue(field["required"])
+            # There are check box fields as well as the comment fields in the form
+            self.assertEqual(field["type"], "text" if field["name"].endswith("_comment") else "boolean")
+            self.assertFalse(field["required"])
         field_names = [field["name"] for field in fields]
         self.assertIn("not-achieved_A1.a.1", field_names)
         self.assertIn("not-achieved_A1.a.4", field_names)
@@ -62,10 +63,10 @@ class FormProvidersTestCase(TestCase):
         provider = OutcomeConfirmationFieldProvider(self.outcome_data)
         fields = provider.get_field_definitions()
         self.assertIsInstance(fields, list)
-        self.assertEqual(len(fields), 2)
+        self.assertEqual(len(fields), 5)
         status_field = next(field for field in fields if field["name"] == "confirm_outcome")
         comments_field = next(field for field in fields if field["name"] == "supporting_comments")
-        self.assertEqual(status_field["type"], "choice_with_justifications")
+        self.assertEqual(status_field["type"], "choice")
         self.assertTrue(status_field["required"])
         choices = [choice[0] for choice in status_field["choices"]]
         self.assertIn("confirm", choices)

--- a/tests/test_indicator_status_calculation.py
+++ b/tests/test_indicator_status_calculation.py
@@ -12,9 +12,9 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "achieved_statement_1": "agreed",
-                        "achieved_statement_2": "not_true_have_justification",
-                        "partially-achieved_statement_2": "not_true_have_justification",
+                        "achieved_statement_1": True,
+                        "achieved_statement_2": True,
+                        "partially-achieved_statement_2": True,
                     },
                 },
                 "Achieved",
@@ -23,8 +23,8 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "achieved_statement_1": "not_true_no_justification",
-                        "achieved_statement_2": "not_true_have_justification",
+                        "achieved_statement_1": False,
+                        "achieved_statement_2": True,
                     },
                 },
                 "Not achieved",
@@ -33,10 +33,10 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "achieved_statement_1": "not_true_no_justification",
-                        "achieved_statement_2": "not_true_have_justification",
-                        "partially-achieved_statement_1": "agreed",
-                        "partially-achieved_statement_2": "not_true_have_justification",
+                        "achieved_statement_1": False,
+                        "achieved_statement_2": True,
+                        "partially-achieved_statement_1": True,
+                        "partially-achieved_statement_2": True,
                     },
                 },
                 "Partially achieved",
@@ -45,8 +45,8 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "partially-achieved_statement_1": "not_true_no_justification",
-                        "partially-achieved_statement_2": "not_true_have_justification",
+                        "partially-achieved_statement_1": False,
+                        "partially-achieved_statement_2": True,
                     },
                 },
                 "Not achieved",
@@ -55,9 +55,9 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "achieved_statement_1": "agreed",
-                        "achieved_statement_2": "agreed",
-                        "partially-achieved_statement_2": "not_true_have_justification",
+                        "achieved_statement_1": True,
+                        "achieved_statement_2": True,
+                        "partially-achieved_statement_2": True,
                     },
                 },
                 "Achieved",
@@ -66,10 +66,10 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "achieved_statement_1": "not_true_no_justification",
-                        "achieved_statement_2": "agreed",
-                        "not_achieved_statement_1": "not_true_no_justification",
-                        "not_achieved_statement_2": "not_true_have_justification",
+                        "achieved_statement_1": False,
+                        "achieved_statement_2": True,
+                        "not_achieved_statement_1": False,
+                        "not_achieved_statement_2": True,
                     },
                 },
                 "Not achieved",
@@ -78,8 +78,8 @@ class TestIndicatorStatusChecker(TestCase):
                 {
                     "confirmation": {"confirm_outcome": None},
                     "indicators": {
-                        "achieved_statement_1": "not_true_no_justification",
-                        "achieved_statement_2": "not_true_have_justification",
+                        "achieved_statement_1": False,
+                        "achieved_statement_2": True,
                     },
                 },
                 "Not achieved",

--- a/webcaf/settings.py
+++ b/webcaf/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 """
 
 import os
-import uuid
 from pathlib import Path
 
 from csp.constants import NONCE, SELF
@@ -38,7 +37,11 @@ if DEBUG:
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY: str = str(uuid.uuid4()) if DEBUG else env.str("SECRET_KEY", default="not_set")  # type: ignore
+SECRET_KEY: str = env.str("SECRET_KEY", default="not_set")  # type: ignore
+
+if SECRET_KEY == "not_set" and not DEBUG:  # pragma: allowlist secret
+    raise Exception("SECRET_KEY must be set in production")
+
 APPEND_SLASH = True
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["*"])
 

--- a/webcaf/webcaf/caf/field_providers.py
+++ b/webcaf/webcaf/caf/field_providers.py
@@ -79,8 +79,14 @@ class OutcomeConfirmationFieldProvider(FieldProvider):
         return [
             {
                 "name": "confirm_outcome",
-                "type": "choice_with_justifications",
-                "choices": status_choices,
+                "type": "choice",
+                "choices": [
+                    (
+                        choice.value,
+                        choice.label,
+                    )
+                    for choice in status_choices
+                ],
                 "required": True,
                 "label": "",
             },
@@ -95,4 +101,19 @@ class OutcomeConfirmationFieldProvider(FieldProvider):
                     "max_words": MAX_WORD_COUNT,
                 },
             },
+        ] + [
+            # Add justification_text for the confirmation choice list
+            {
+                "name": f"confirm_outcome_{status_choice.value}_comment",
+                "label": "Tell us your justifications",
+                "type": "text",
+                "required": False,
+                "widget_attrs": {
+                    "rows": 5,
+                    "class": "govuk-textarea",
+                    "max_words": MAX_WORD_COUNT,
+                },
+            }
+            for status_choice in status_choices
+            if status_choice.needs_justification_text
         ]

--- a/webcaf/webcaf/caf/field_providers.py
+++ b/webcaf/webcaf/caf/field_providers.py
@@ -21,56 +21,32 @@ class OutcomeIndicatorsFieldProvider(FieldProvider):
 
     def get_field_definitions(self) -> list[dict]:
         fields = []
-        justifications = {
-            "not-achieved": [
-                AchievementChoice(
-                    "true_have_justification",
-                    "This does apply to my system or organisation and I have justifications",
-                    True,
-                ),
-                AchievementChoice(
-                    "agreed",
-                    "This does apply to my system or organisation, but I have no justifications",
-                    False,
-                ),
-                AchievementChoice(
-                    "not_true_no_justification", "This does not apply to my system or organisation", False
-                ),
-            ],
-            "achieved": [
-                AchievementChoice("agreed", "True", False),
-                AchievementChoice("not_true_have_justification", "Not true, but I do have justifications", True),
-                AchievementChoice("not_true_no_justification", "Not true, and I have no justifications", False),
-            ],
-            "partially-achieved": [
-                AchievementChoice("agreed", "True", False),
-                AchievementChoice("not_true_have_justification", "Not true, but I do have justifications", True),
-                AchievementChoice("not_true_no_justification", "Not true, and I have no justifications", False),
-            ],
-        }
         for level in ["not-achieved", "partially-achieved", "achieved"]:
             if level in self.outcome_data.get("indicators", {}):
                 for indicator_id, indicator_text in self.outcome_data["indicators"][level].items():
-                    justication_for_id = [
-                        justification.value
-                        for justification in justifications[level]
-                        if justification.needs_justification_text
-                    ][0]
                     fields.append(
                         {
                             "name": f"{level}_{indicator_id}",
                             "label": indicator_text["description"],
-                            "type": "choice_with_justifications",
-                            "required": True,
-                            "choices": justifications[level],
-                            "widget_attrs": {
-                                "rows": 5,
-                                "class": "govuk-textarea",
-                                "max_words": MAX_WORD_COUNT,
-                                "id": f"{level}_{indicator_id}_{justication_for_id}_comment".replace(".", "_"),
-                            },
+                            "type": "boolean",
+                            "required": False,
                         }
                     )
+                    # Not achieved choices have an extra justification field
+                    if level in ["not-achieved"]:
+                        fields.append(
+                            {
+                                "name": f"{level}_{indicator_id}_comment",
+                                "label": "Tell us your justification",
+                                "type": "text",
+                                "required": False,
+                                "widget_attrs": {
+                                    "rows": 5,
+                                    "class": "govuk-textarea",
+                                    "max_words": MAX_WORD_COUNT,
+                                },
+                            }
+                        )
 
         return fields
 

--- a/webcaf/webcaf/caf/util.py
+++ b/webcaf/webcaf/caf/util.py
@@ -32,11 +32,11 @@ class IndicatorStatusChecker:
 
         # Determine achieved
         outcome_status: str
-        if achieved_items and all(v in ["agreed", "not_true_have_justification"] for _, v in achieved_items):
+        if achieved_items and all(v for _, v in achieved_items):
             outcome_status = "Achieved"
         else:
             # Determine partially achieved
-            if partial_items and all(v in ["agreed", "not_true_have_justification"] for _, v in partial_items):
+            if partial_items and all(v for _, v in partial_items):
                 outcome_status = "Partially achieved"
             else:
                 outcome_status = "Not achieved"

--- a/webcaf/webcaf/caf/views/factory.py
+++ b/webcaf/webcaf/caf/views/factory.py
@@ -125,8 +125,13 @@ class BaseIndicatorsFormView(FormViewWithBreadcrumbs):
                 assessment.assessments_data[self.class_id][self.stage]
                 and assessment.assessments_data[self.class_id][self.stage] != form.cleaned_data
             ):
-                # Reset the confirmation data if the form data has changed
-                assessment.assessments_data[self.class_id]["confirmation"] = {}
+                # Reset the confirmation data if the form data has changed.
+                # Keep supporting comments unchanged as the user may want to reuse it.
+                assessment.assessments_data[self.class_id]["confirmation"] = {
+                    k: v
+                    for k, v in assessment.assessments_data[self.class_id]["confirmation"].items()
+                    if k in ["supporting_comments"]
+                }
             assessment.assessments_data[self.class_id][self.stage] = form.cleaned_data
             assessment.last_modified_by = current_user_profile.user
             assessment.save()
@@ -198,11 +203,11 @@ class OutcomeIndicatorsView(BaseIndicatorsFormView):
             for field_name, value in fields_needing_justification:
                 if not cleaned_data[f"{field_name}_comment"]:
                     form.add_error(field_name, ValidationError("You must provide a justification."))
-            form.initial.update(form.cleaned_data)
             # We directly call super as we don't want to call form_invalid here.'This is because
             # form_invalid will us purly to capture non selected questions and we cannot have
             # optional logic to handle this.
         if form.errors:
+            form.initial.update(form.cleaned_data)
             return super().form_invalid(form)
         return super().form_valid(form)
 
@@ -328,6 +333,10 @@ class OutcomeConfirmationView(BaseIndicatorsFormView):
         """
         assessment = SessionUtil.get_current_assessment(self.request)
         return reverse_lazy(f"{assessment.framework}_objective_{self.extra_context['objective_code']}")
+
+    def form_invalid(self, form):
+        form.initial.update(form.cleaned_data)
+        return super().form_invalid(form)
 
 
 create_form_view_logger = logging.getLogger("create_form_view")

--- a/webcaf/webcaf/forms/factory.py
+++ b/webcaf/webcaf/forms/factory.py
@@ -43,8 +43,11 @@ def create_form(provider: FieldProvider) -> type[forms.Form]:  # noqa: C901
     form_fields = {}
     for field_def in field_defs:
         if field_def["type"] == "boolean":
+            widget_attrs = field_def.get("widget_attrs", {})
             form_fields[field_def["name"]] = forms.BooleanField(
-                label=field_def["label"], required=field_def.get("required", False), widget=forms.CheckboxInput()
+                label=field_def["label"],
+                required=field_def.get("required", False),
+                widget=forms.CheckboxInput(attrs=widget_attrs),
             )
         elif field_def["type"] == "choice":
             widget = None
@@ -57,26 +60,6 @@ def create_form(provider: FieldProvider) -> type[forms.Form]:  # noqa: C901
                 initial=field_def.get("initial"),
                 widget=widget,
             )
-        elif field_def["type"] == "choice_with_justifications":
-            form_fields[field_def["name"]] = forms.ChoiceField(  # type: ignore
-                label=field_def["label"],
-                choices=[(choice.value, choice.label) for choice in field_def["choices"]],
-                required=field_def.get("required", True),
-                initial=field_def.get("initial"),
-            )
-            for choice in field_def["choices"]:
-                # Needs justification field
-                if choice.needs_justification_text:
-                    widget_attrs = field_def.get("widget_attrs", {})
-                    form_fields[f"{field_def['name']}_{choice.value}_comment"] = forms.CharField(  # type: ignore
-                        label="Extra information",
-                        # This will be validated in the form's clean method'
-                        required=False,
-                        widget=forms.Textarea(attrs=widget_attrs) if widget_attrs else None,
-                        validators=(
-                            [WordCountValidator(widget_attrs.get("max_words"))] if widget_attrs.get("max_words") else []
-                        ),
-                    )
         elif field_def["type"] == "text":
             widget_attrs = field_def.get("widget_attrs", {})
             form_fields[field_def["name"]] = forms.CharField(  # type: ignore

--- a/webcaf/webcaf/static/application.css
+++ b/webcaf/webcaf/static/application.css
@@ -28,17 +28,17 @@ span.govuk-header__logotype-text {
     color: #003078; /* GOV.UK link hover colour */
 }
 
-
-.govuk-radios__input:checked ~ .govuk-radios__conditional--hidden {
-    display: block;
-    visibility: visible;
+.govuk-checkboxes__conditional {
+    margin-bottom: 15px;
+    margin-left: 20px;
+    padding-left: 35px;
+    border-left: 4px solid #b1b4b6;
+    width: 100%;
+    display: none;
+    visibility: hidden;
 }
 
-.govuk-radios__conditional--hidden {
-    flex-basis: 100%;
-    margin-left: 1em;
-    padding-left: 2em;
-    border-left: 4px solid #b1b4b6;
-    padding-bottom: 0;
-    margin-bottom: 0;
+.govuk-checkboxes__input:checked ~ .govuk-checkboxes__conditional {
+    display: block;
+    visibility: visible;
 }

--- a/webcaf/webcaf/static/application.css
+++ b/webcaf/webcaf/static/application.css
@@ -28,7 +28,7 @@ span.govuk-header__logotype-text {
     color: #003078; /* GOV.UK link hover colour */
 }
 
-.govuk-checkboxes__conditional {
+.govuk-checkboxes__conditional, .govuk-radios__conditional {
     margin-bottom: 15px;
     margin-left: 20px;
     padding-left: 35px;
@@ -39,6 +39,11 @@ span.govuk-header__logotype-text {
 }
 
 .govuk-checkboxes__input:checked ~ .govuk-checkboxes__conditional {
+    display: block;
+    visibility: visible;
+}
+
+.govuk-radios__input:checked ~ .govuk-radios__conditional {
     display: block;
     visibility: visible;
 }

--- a/webcaf/webcaf/templates/caf/confirmation.html
+++ b/webcaf/webcaf/templates/caf/confirmation.html
@@ -28,34 +28,34 @@
             <form method="post">
                 {% csrf_token %}
                 <div class="govuk-form-group">
-                    <div class="govuk-radios" data-module="govuk-radios" data-govuk-radios-init="">
+                    <div class="govuk-radios {% if form.confirm_outcome.errors %}govuk-form-group--error{% endif %}" data-module="govuk-radios" data-govuk-radios-init="">
                         {% for choice in form.fields.confirm_outcome.choices %}
-                            <div class="govuk-radios__item override-item"
-                                 id="div_{{ form.fields.confirm_outcome.auto_id }}">
+                            <div class="govuk-radios__item "
+                                 id="id_confirm_outcome">
                                 <input class="govuk-radios__input"
-                                       id="{{ form.fields.confirm_outcome.auto_id }}-{{ forloop.counter }}"
+                                       id="{{ form.confirm_outcome.auto_id }}-{{ forloop.counter }}"
                                        name="confirm_outcome"
                                        value="{{ choice.0 }}"
                                        {% if choice.0 == form.confirm_outcome.initial %}checked{% endif %}
                                        type="radio">
                                 <label class="govuk-label govuk-radios__label"
-                                       for="{{ form.fields.confirm_outcome.auto_id }}-{{ forloop.counter }}">
+                                       for="{{ form.confirm_outcome.auto_id }}-{{ forloop.counter }}">
                                     {{ choice.1 }}
                                 </label>
                                 {% get_comment_field form form.fields.confirm_outcome.name choice.0 as the_field_comment %}
                                 {% if the_field_comment %}
                                     <div id="{{ section_type }}-{{ forloop.parentloop.counter }}-{{ forloop.counter }}_container"
-                                         class="govuk-radios__conditional--hidden">
+                                         class="govuk-radios__conditional">
                                         <label class="govuk-label comments_label div_id_{{ item.name }}_comments_label"
-                                               for="div_id_{{ item.name }}_comments">
-                                            Tell us your justifications
+                                               for="{{the_field_comment.auto_id|safe_id}}">
+                                            {{ the_field_comment.label }}
                                         </label>
                                         <!-- @formatter:off -->
-                                    {#                            Disable formatting the text area as it introduces spaces if wrongly formatted#}
+                                    {# Disable formatting the text area as it introduces spaces if wrongly formatted#}
                                     <textarea class="govuk-textarea comments_textarea"
-                                              id="div_id_{{ item.name }}_comments"
+                                              id="{{the_field_comment.auto_id|safe_id}}"
                                               name="{{ the_field_comment.name }}"
-                                              rows="5">{{ the_field_comment.initial|default:"" }}</textarea>
+                                              rows="5">{{ the_field_comment|striptags|default:"" }}</textarea>
                                     <!-- @formatter:on -->
                                     </div>
                                 {% endif %}
@@ -96,7 +96,7 @@
                             the outcomes and IGPs, because the assessor will compare your responses.</p></div>
                 </details>
                 <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                     data-maxwords={{form.supporting_comments.field.widget.attrs.max_words}}>
+                     data-maxwords={{ form.supporting_comments.field.widget.attrs.max_words }}>
                     <h1 class="govuk-label-wrapper">
                         <label class="govuk-label" for="summary_outline">
                             Please write a short summary outlining how you worked towards achieving this outcome.
@@ -111,7 +111,8 @@
                               name="supporting_comments" rows="5"
                               aria-describedby="summary_outline-info summary_outline-hint">{{ form.supporting_comments|striptags|default:"" }}</textarea>
                     <!-- @formatter:on -->
-                    <div id="id_supporting_comments-info" class="govuk-hint govuk-character-count__message">You can enter up to
+                    <div id="id_supporting_comments-info" class="govuk-hint govuk-character-count__message">You can
+                        enter up to
                         {{ form.supporting_comments.field.widget.attrs.max_words }} words
                     </div>
                 </div>

--- a/webcaf/webcaf/templates/caf/indicators.html
+++ b/webcaf/webcaf/templates/caf/indicators.html
@@ -67,14 +67,6 @@
                         </div>
                     </fieldset>
                 </div>
-
-                <div class="govuk-warning-text">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                    <strong class="govuk-warning-text__text">
-                        <span class="govuk-visually-hidden">Warning</span>
-                        Before you click 'Save and continue', you must answer 'Achieved' and 'Not achieved' statements.
-                    </strong>
-                </div>
                 <div class="govuk-button-group">
                     <button type="submit" class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
                         Save and continue

--- a/webcaf/webcaf/templates/caf/indicators.html
+++ b/webcaf/webcaf/templates/caf/indicators.html
@@ -9,66 +9,65 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {% include "partials/error_message.html" %}
-            <h3 class="govuk-heading-m">Read each statement in all tabs and select what's true about your system or
-                organisation.</h3>
+            <h3 class="govuk-body-l">Read each indicator of good practice (IGP) statement and select what's true about
+                your system or organisation.</h3>
             <form class="form" id="mainForm" method="post">
                 {% csrf_token %}
-                <div class="govuk-tabs" data-module="govuk-tabs">
-                    <h2 class="govuk-tabs__title">
-                        Statements
-                    </h2>
-                    <ul class="govuk-tabs__list">
-                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-                            <a class="govuk-tabs__tab" href="#achieved">
-                                Achieved
-                            </a>
-                        </li>
-                        {% if form|filter_fields:"partially-achieved"|length > 0 %}
-                            <li class="govuk-tabs__list-item">
-                                <a class="govuk-tabs__tab" href="#partially_achieved">
-                                    Partially achieved
-                                </a>
-                            </li>
-                        {% endif %}
-                        <li class="govuk-tabs__list-item">
-                            <a class="govuk-tabs__tab" href="#not_achieved">
-                                Not achieved
-                            </a>
-                        </li>
-                    </ul>
-                    <div class="govuk-tabs__panel" id="achieved">
-                        <h1 class="govuk-heading-s">Achieved statements</h1>
-                        <div id="signIn-hint" class="govuk-hint">To achieve this outcome you must answer true to all
-                            statements.
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="a3aAc-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h1 class="govuk-fieldset__heading">
+                                Achieved statements
+                            </h1>
+                        </legend>
+                        <div id="a3aAc-hint" class="govuk-hint">
+                            To achieve this outcome you must select all achieved statements.
                         </div>
-                        <div class="govuk-warning-text">
-                            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                            <strong class="govuk-warning-text__text">
-                                <span class="govuk-visually-hidden">Warning</span>
-                                If you cannot select true for a statement, you must select not true and provide your
-                                justifications. If you don't have a justification, you will fail this outcome.
-                            </strong>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes" data-govuk-checkboxes-init="">
+                            {% for item in form|filter_fields:"achieved" %}
+                                {% include "caf/partials/statement_fieldset.html" with section_type="achieved" field_name_prefix="achieved" %}
+                            {% endfor %}
                         </div>
-                        {% for item in form|filter_fields:"achieved" %}
-                            {% include "caf/partials/statement_fieldset.html" with section_type="achieved" field_name_prefix="achieved" %}
-                        {% endfor %}
-                    </div>
-                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="partially_achieved">
-                        <h1 class="govuk-heading-s">Partially achieved statements</h1>
-                        {% for item in form|filter_fields:"partially-achieved" %}
-                            {% include "caf/partials/statement_fieldset.html" with section_type="partially-achieved" field_name_prefix="partially-achieved" %}
-                        {% endfor %}
-                    </div>
-                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="not_achieved">
-                        <h1 class="govuk-heading-s">Not achieved statements</h1>
-                        <div id="signIn-hint" class="govuk-hint">If any statement applies to your system or organisation
-                            in this section you must provide justifications otherwise you will fail this outcome.
-                        </div>
-                        {% for item in form|filter_fields:"not-achieved" %}
-                            {% include "caf/partials/statement_fieldset.html" with section_type="not-achieved" field_name_prefix="not-achieved" %}
-                        {% endfor %}
-                    </div>
+                    </fieldset>
                 </div>
+                {% if form|filter_fields:"partially-achieved"|length > 0 %}
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset" aria-describedby="pa3aAc-hint">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                <h1 class="govuk-fieldset__heading">
+                                    Partially achieved statements
+                                </h1>
+                            </legend>
+                            <div id="pa3aAc-hint" class="govuk-hint">
+                                To partially achieve this outcome you must select all partially achieved statements.
+                            </div>
+                            <div class="govuk-checkboxes" data-module="govuk-checkboxes" data-govuk-checkboxes-init="">
+                                {% for item in form|filter_fields:"partially-achieved" %}
+                                    {% include "caf/partials/statement_fieldset.html" with section_type="partially-achieved" field_name_prefix="partially-achieved" %}
+                                {% endfor %}
+                            </div>
+                        </fieldset>
+                    </div>
+                {% endif %}
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset" aria-describedby="a3aNa-hint">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h1 class="govuk-fieldset__heading">
+                                Not achieved statements
+                            </h1>
+                        </legend>
+                        <div id="a3aNa-hint" class="govuk-hint">
+                            If you select any statement that applies to your system or organisation in this section you
+                            must provide justifications otherwise you will fail this outcome.
+                        </div>
+                        <div class="govuk-checkboxes" data-module="govuk-checkboxes" data-govuk-checkboxes-init="">
+                            {% for item in form|filter_fields:"not-achieved" %}
+                                {% include "caf/partials/statement_fieldset.html" with section_type="not-achieved" field_name_prefix="not-achieved" %}
+                            {% endfor %}
+                        </div>
+                    </fieldset>
+                </div>
+
                 <div class="govuk-warning-text">
                     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
                     <strong class="govuk-warning-text__text">

--- a/webcaf/webcaf/templates/caf/partials/statement_fieldset.html
+++ b/webcaf/webcaf/templates/caf/partials/statement_fieldset.html
@@ -1,12 +1,12 @@
 {% load form_extras %}
-<div class="govuk-checkboxes__item">
+<div class="govuk-checkboxes__item " >
     <input class="govuk-checkboxes__input" id="{{ item.auto_id|safe_id }}" name="{{ item.name }}" type="checkbox"
            value="agreed"
             {% if item.value %}
            checked="checked"
             {% endif %}
     >
-    <label class="govuk-label govuk-checkboxes__label" for="{{ item.auto_id|safe_id }}">
+    <label class="govuk-label govuk-checkboxes__label {% if item.errors %}govuk-form-group--error{% endif %}" for="{{ item.auto_id|safe_id }}">
         {{ forloop.counter }}. {{ item.field.label }}
         {% if item.field.label_suffix %}
             <span class="govuk-tag--green govuk-!-font-size-16">

--- a/webcaf/webcaf/templates/caf/partials/statement_fieldset.html
+++ b/webcaf/webcaf/templates/caf/partials/statement_fieldset.html
@@ -1,61 +1,36 @@
 {% load form_extras %}
-<div class="govuk-form-group {% if item.errors %}govuk-form-group--error{% endif %}">
-    <fieldset class="govuk-fieldset" aria-describedby="outcome{{ forloop.counter }}-{{ section_type }}-hint">
-        <legend class="govuk-fieldset__legend govuk">
-            <h1 class="govuk-fieldset__heading">
-                {{ forloop.counter }}. {{ item.field.label }}
-                {% if item.field.label_suffix %}
-                    <span class="govuk-tag--green govuk-!-font-size-16">
-                        {{ item.field.label_suffix }}
-                    </span>
-                {% endif %}
-            </h1>
-        </legend>
-        <div id="outcome{{ forloop.counter }}-{{ section_type }}-hint" class="govuk-hint">
-        </div>
-        {# Assign the id at the top level so that we can navigate from the error message   #}
-        <div id="{{ item.auto_id|safe_id }}" class="govuk-radios" data-module="govuk-radios" data-govuk-radios-init="">
-            {% for choice in item.field.choices %}
-                <div class="govuk-radios__item override-item">
-                    <input class="govuk-radios__input"
-                           id="{{ item.auto_id }}-{{ forloop.counter }}"
-                           name="{{ item.name }}"
-                           value="{{ choice.0 }}"
-                           {% if choice.0 == item.initial %}checked{% endif %}
-                           type="radio">
-                    <label class="govuk-label govuk-radios__label"
-                           for="{{ item.auto_id }}-{{ forloop.counter }}">
-                        {{ choice.1 }}
-                    </label>
-                    {% get_comment_field form item.name choice.0 as the_field_comment %}
-                    {% if the_field_comment %}
-                        <div id="{{ section_type }}-{{ forloop.parentloop.counter }}-{{ forloop.counter }}_container"
-                             class="govuk-radios__conditional--hidden">
-                            <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
-                            data-maxwords={{the_field_comment.field.widget.attrs.max_words}}>
-                             <h1 class="govuk-label-wrapper">
-                                <label class="govuk-label comments_label id_{{ the_field_comment.field.widget.attrs.id }}_label"
-                                    for="id_{{ the_field_comment.field.widget.attrs.id }}">
-                                    Tell us your justifications
-                                </label>
-                            </h1>
-                            <!-- @formatter:off -->
-{#                            Disable formatting the text area as it introduces spaces if wrongly formatted#}
-
-                            <textarea class="govuk-textarea govuk-js-character-count"
-                                      data-module="govuk-character-count"
-                                      id="id_{{ the_field_comment.field.widget.attrs.id }}"
-                                      name="{{ the_field_comment.name }}"
-                                      rows="5">{{ the_field_comment|striptags|default:"" }}</textarea>
-                            <div id="id_{{ the_field_comment.field.widget.attrs.id }}-info" class="govuk-hint govuk-character-count__message">You can enter up to
-                                {{the_field_comment.field.widget.attrs.max_words}} words
-                             </div>
-                            <!-- @formatter:on -->
-                        </div>
-                        </div>
-                    {% endif %}
+<div class="govuk-checkboxes__item">
+    <input class="govuk-checkboxes__input" id="{{ item.auto_id|safe_id }}" name="{{ item.name }}" type="checkbox"
+           value="agreed"
+            {% if item.value %}
+           checked="checked"
+            {% endif %}
+    >
+    <label class="govuk-label govuk-checkboxes__label" for="{{ item.auto_id|safe_id }}">
+        {{ forloop.counter }}. {{ item.field.label }}
+        {% if item.field.label_suffix %}
+            <span class="govuk-tag--green govuk-!-font-size-16">
+                                {{ item.field.label_suffix }}</span>
+        {% endif %}
+    </label>
+    {% get_comment_field form item.name as the_field_comment %}
+    {% if the_field_comment %}
+        <div class="govuk-checkboxes__conditional" id="conditional-{{ the_field_comment.auto_id|safe_id }}">
+            <div class="govuk-form-group govuk-character-count" data-module="govuk-character-count"
+                 data-maxwords={{ the_field_comment.field.widget.attrs.max_words }}>
+                <label class="govuk-label" for="{{ the_field_comment.auto_id|safe_id }}">
+                    {{ the_field_comment.label }}
+                </label>
+                <textarea class="govuk-textarea govuk-js-character-count"
+                          id="{{ the_field_comment.auto_id|safe_id }}"
+                          data-module="govuk-character-count"
+                          name="{{ the_field_comment.name }}"
+                          rows="5">{{ the_field_comment|striptags|default:"" }}</textarea>
+                <div id="{{ the_field_comment.auto_id|safe_id }}-info"
+                     class="govuk-hint govuk-character-count__message">You can enter up to
+                    {{ the_field_comment.field.widget.attrs.max_words }} words
                 </div>
-            {% endfor %}
+            </div>
         </div>
-    </fieldset>
+    {% endif %}
 </div>

--- a/webcaf/webcaf/templates/partials/error_message.html
+++ b/webcaf/webcaf/templates/partials/error_message.html
@@ -18,45 +18,4 @@
             </ul>
         </div>
     </div>
-    <script nonce="{{ request.csp_nonce }}">
-        document.querySelectorAll("ul.govuk-list.govuk-error-summary__list a")
-            .forEach(function (anchor) {
-                anchor.addEventListener("click", function (event) {
-                    event.preventDefault();
-
-                    const targetSelector = anchor.getAttribute("href");
-                    const targetElement = document.querySelector(targetSelector);
-
-                    if (targetElement) {
-                        // Step 1: find parent tab panel
-                        const tabPanel = targetElement.closest(".govuk-tabs__panel");
-                        if (tabPanel) {
-                            const panelId = tabPanel.id;
-
-                            // Step 2: find tab button that activates this panel
-                            const tabButton = document.querySelector(
-                                `.govuk-tabs__list-item a[href="#${panelId}"]`
-                            );
-
-                            if (tabButton) {
-                                // Activate the tab using the GOV.UK Tabs API (preferred)
-                                const tabs = document.querySelector(".govuk-tabs");
-                                if (tabs && tabs.GOVUKTabs) {
-                                    tabs.GOVUKTabs.showPanel(tabPanel.id);
-                                } else {
-                                    // Fallback: simulate click on the tab button
-                                    tabButton.click();
-                                }
-                            }
-                        }
-
-                        // Step 3: scroll smoothly to the target
-                        setTimeout(() => {
-                            targetElement.scrollIntoView({behavior: "smooth", block: "center"});
-                            targetElement.focus({preventScroll: true}); // accessibility
-                        }, 200); // slight delay so tab panel has time to open
-                    }
-                });
-            })
-    </script>
 {% endif %}

--- a/webcaf/webcaf/templatetags/form_extras.py
+++ b/webcaf/webcaf/templatetags/form_extras.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any
+from typing import Any, Optional
 
 from django import template
 
@@ -28,7 +28,7 @@ def filter_fields(form, prefix):
 
 
 @register.simple_tag
-def get_comment_field(form, field_name, choice):
+def get_comment_field(form, field_name, prefix: Optional[str] = None):
     """
     Retrieve a comment field from the given form based on the specified field name and choice.
 
@@ -42,15 +42,18 @@ def get_comment_field(form, field_name, choice):
     :param field_name: The base name of the field to search for. All matching
         fields should start with this base name.
     :type field_name: str
-    :param choice: The choice identifier to narrow down the field search. All
+    :param prefix: The choice identifier to narrow down the field search. All
         matching fields should end with this choice followed by "_comment".
-    :type choice: str
+    :type prefix: str
     :return: The matched form field if found, otherwise None.
     :rtype: Optional[Any]
     """
-    matched_fields = [
-        field for field in form if field.name.startswith(field_name) and field.name.endswith(f"_{choice}_comment")
-    ]
+    if prefix is None:
+        suffix = "_comment"
+    else:
+        suffix = f"_{prefix}_comment"
+
+    matched_fields = [field for field in form if field.name.startswith(field_name) and field.name.endswith(suffix)]
     if matched_fields:
         return matched_fields[0]
     return None


### PR DESCRIPTION
1. Updated `get_comment_field` function to accept an optional prefix parameter for more flexible field search.
2. Refactored the statement fieldset template to use checkboxes instead of radios, enhancing UI consistency and error handling.
3. Enhanced assessment retrieval by adding configurable status filtering and improved error messages in templates.
