### PR TITLE
Removed completed on time section, button text change

### DIFF
--- a/webcaf/webcaf/forms/general.py
+++ b/webcaf/webcaf/forms/general.py
@@ -33,24 +33,6 @@ class NextActionForm(Form):
     )
 
 
-class HeadingConfirmationForm(Form):
-    """
-    A form to confirm whether an objective has been completed on time.
-
-    This form is used to collect user input for verifying if the objective
-    was completed within the intended deadline. It includes a single field
-    for this purpose.
-
-    :ivar completed_on_time: A field indicating whether the objective was
-        completed on time.
-    :type completed_on_time: forms.BooleanField
-    """
-
-    completed_on_time = forms.BooleanField(
-        required=True,
-    )
-
-
 class UserProfileForm(forms.ModelForm):
     first_name = forms.CharField(max_length=150, required=True)
     last_name = forms.CharField(max_length=150, required=True)

--- a/webcaf/webcaf/templates/caf/assessment/objective-confirmation.html
+++ b/webcaf/webcaf/templates/caf/assessment/objective-confirmation.html
@@ -27,44 +27,8 @@
             {% if all_objectives_complete and can_submit %}
                 <form method="post">
                     {% csrf_token %}
-                    <h2 class="govuk-heading-l">Confirm your self-assessment submission date</h2>
-                    <p class="govuk-body">Submissions close for GovAssure Year 3 2025/26 at 11:59pm on 31 March 2026. If
-                        you
-                        provide your
-                        self-assessment after this date, it will be filed for Year 4 2026/27.
-                    </p>
-                    <div class="govuk-form-group">
-                        <fieldset class="govuk-fieldset">
-                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                                <h1 class="govuk-fieldset__heading">
-                                    Are you submitting your self-assessment before the closing date of 11:59pm on 31
-                                    March 2026?
-                                </h1>
-                            </legend>
-                            <div id="id_completed_on_time" class="govuk-radios govuk-radios--inline"
-                                 data-module="govuk-radios"
-                                 data-govuk-radios-init="">
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="completed_on_time_yes"
-                                           name="completed_on_time"
-                                           type="radio" value="yes">
-                                    <label class="govuk-label govuk-radios__label" for="completed_on_time_yes">
-                                        Yes
-                                    </label>
-                                </div>
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="completed_on_time_no"
-                                           name="completed_on_time"
-                                           type="radio" value="no">
-                                    <label class="govuk-label govuk-radios__label" for="completed_on_time_no">
-                                        No
-                                    </label>
-                                </div>
-                            </div>
-                        </fieldset>
-                    </div>
                     <button type="submit" class="govuk-button" data-module="govuk-button" data-govuk-button-init="">
-                        Save and continue
+                        Save and send for review
                     </button>
                 </form>
             {% endif %}

--- a/webcaf/webcaf/views/sections.py
+++ b/webcaf/webcaf/views/sections.py
@@ -3,11 +3,11 @@ import random
 import string
 from datetime import datetime
 
+from django.forms import Form
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import FormView, TemplateView
 
-from webcaf.webcaf.forms.general import HeadingConfirmationForm
 from webcaf.webcaf.templatetags.form_extras import (
     get_assessment,
     is_all_objectives_complete,
@@ -30,7 +30,7 @@ class SectionConfirmationView(UserRoleCheckMixin, FormView):
     """
 
     template_name = "assessment/objective-confirmation.html"
-    form_class = HeadingConfirmationForm
+    form_class = Form
     logger = logging.Logger("ObjectiveConfirmationView")
 
     def get_allowed_roles(self) -> list[str]:


### PR DESCRIPTION
The changes are for the following requirements:

1. Remove the heading and content section “Confirm the date you are sending your self-assessment”. This is no-longer needed here.
2. Rename the button from 'Save and continue' to 'Save and send for review'.