### PR TITLE
Remove sent for review section for cyber advisor

### DIFF
--- a/webcaf/webcaf/templates/user-pages/my-account.html
+++ b/webcaf/webcaf/templates/user-pages/my-account.html
@@ -71,10 +71,12 @@
                         </a>
                     </p>
                 {% endif %}
-                <h3 class="govuk-heading-m">
-                    Assessments sent for review
-                </h3>
-                <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">You didn't submit an assessment.
+                {% if current_user_can_submit_assessment %}
+                    <h3 class="govuk-heading-m">
+                        Assessments sent for review
+                    </h3>
+                    <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">You didn't submit an assessment.
+                {% endif %}
             {% endif %}
         </div>
 


### PR DESCRIPTION
This removes the section showing assessments sent for review from the my account page for users with a cyber advisor user profile