### PR TITLE
Add content for footer link pages

### DIFF
--- a/webcaf/urls.py
+++ b/webcaf/urls.py
@@ -17,6 +17,7 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 from webcaf.webcaf.views import (
     AccountView,
@@ -109,4 +110,8 @@ urlpatterns = [
     path("edit-profile/<int:user_profile_id>", UserProfileView.as_view(), name="edit-profile"),
     path("remove-profile/<int:user_profile_id>", RemoveUserProfileView.as_view(), name="remove-profile"),
     path("view-profiles/", UserProfilesView.as_view(), name="view-profiles"),
+    path("data-usage-policy/", TemplateView.as_view(template_name="data-policy.html")),
+    path("cookies/", TemplateView.as_view(template_name="cookies.html")),
+    path("privacy/", TemplateView.as_view(template_name="privacy.html")),
+    path("help/", TemplateView.as_view(template_name="help.html")),
 ]

--- a/webcaf/webcaf/templates/base.html
+++ b/webcaf/webcaf/templates/base.html
@@ -192,8 +192,8 @@
             {% gds_footer_meta_item href="/privacy" text="Privacy" %}
             {% gds_footer_meta_item href="/cookies" text="Cookies" %}
             {% gds_footer_meta_item href="/accessibility" text="Accessibility statement" %}
-            {% gds_footer_meta_item href="/terms" text="Terms and conditions" %}
-
+            {% gds_footer_meta_item href="/data-usage-policy" text="Data usage policy" %}
+            {% gds_footer_meta_item href="/help" text="Help" %}
         {% endgds_footer_meta %}
     {% endgds_footer %}
 {% endblock %}

--- a/webcaf/webcaf/templates/data-policy.html
+++ b/webcaf/webcaf/templates/data-policy.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Data usage policy
+      <br><span class="govuk-body govuk-!-font-size-16  ">Last updated on 27 September 2025.
+            </span></h1>
+
+
+      <h2 class="govuk-heading-m">
+        Who we are
+      </h2>
+      <p class="govuk-body">
+       WebCAF is managed by the Central Digital and Data Office (CDDO) and the Government Security Group (GSG). CDDO and GSG are part of the Cabinet Office. All individuals who have WebCAF administrator rights hold SC clearances.
+      </p>
+      <h3 class="govuk-heading-m">
+        How your data is used in GovAssure
+      </h3>
+
+      <p class="govuk-body">For CAF assessments requiring review, the data you input into WebCAF will be used by external independent assurance reviewers ("assessors") to inform their third party assessments and subsequent reports.
+      </p>
+      <p class="govuk-body">The lead(s) for each government organisation ("organisation leads") are able to set up and assign users and assessors to relevant assessments, giving them the appropriate permissions. Organisations are responsible for ensuring roles and access rights allocated to individuals are appropriate and proportionate to the individual, using the principle of least privilege.
+      </P>
+      <p class="govuk-body">From WebCAF, datasets will be generated that are anonymised for the names of and references to specific organisations and systems. These datasets will be used to produce reporting on government security for the Cabinet Office, and to measure progress against the
+        <a href="https://www.gov.uk/government/publications/government-cyber-security-strategy-2022-to-2030/government-cyber-security-strategy-2022-to-2030-html" class="govuk-link--no-visited-state">Government Cyber Security Strategy</a>
+        This process will include sharing anonymised data with the National Cyber Security Centre (NCSC), the Cyber Government Security Centre (GSeC), the Government Cyber Coordination Centre (GC3), and the Central Digital and Data Office (CDDO).
+      </p>
+      <h3 class="govuk-heading-m">
+        How your data is stored and managed
+      </h3>
+     <p class="govuk-body">In-progress CAF returns are stored on WebCAF and are editable by all of your organisation users, as well any system users your organisation lead has assigned. Once complete and progressed, further edits are not possible.
+      </p>
+      <p class="govuk-body">If an assessment has been progressed to review, it will remain viewable but not editable during the independent assurance review. The assessor(s) who your organisation lead has assigned will be able to view your data and complete their assessment. Once assessors have submitted, your organisation will be able to view (but not edit) the completed CAF return, with both your organisation's and the assessor's answers and comments.
+      </p>
+      <p class="govuk-body">You will then be able to submit your CAF return to GSG. Owing to the aggregate risk of multiple Government organisations using WebCAF, we will transfer the CAF return to a tier two storage environment two weeks from submission. The data will then be unavailable to view through WebCAF. Following submission, only limited metadata will be visible to show what was submitted and when, for your records.
+      </p>
+      <p class="govuk-body">At any point until the assessment has been submitted to GSG, organisation leads are able to make an export of your assessment to download and store for your organisation's records.
+      </p>
+
+
+      <h2 class="govuk-heading-m">
+        Further information
+      </h2>
+
+      <p class="govuk-body">WebCAF has passed the Cabinet Office digital approvals process. Throughout the build of WebCAF, the National Cyber Security Centre has provided technical expertise and guidance. The development of WebCAF aligns and adheres with the
+         <a class="govuk-link" href="https://www.gov.uk/guidance/the-technology-code-of-practice">CDDO's Service Standard and Technology Code of Practice</a>; for example, the application has appropriate access controls, uses continuous integration and deployment from GitHub, logs and monitors usage and audit data, integrates continuous static and dynamic code analysis to identify vulnerability and configuration issues, and runs via iterative development process to quickly remediate issues and adapt features.</p>
+      <p class="govuk-body">A <a class="govuk-link" href="privacy">privacy notice</a> is available around the use of personal data which is linked with a Data Protection Impact Assessment that the GSG and CDDO team have performed with support from Cabinet Office Data Protection Office.
+      </p>
+
+      <p class="govuk-body">For more help on WebCAF, including contact details for the GovAssure and WebCAF teams and information on user roles, please visit the
+        <a class="govuk-link" href="help">help page</a>.
+      </p>
+
+    </div>
+  </div>
+
+{% endblock %}

--- a/webcaf/webcaf/templates/help.html
+++ b/webcaf/webcaf/templates/help.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block content %}
+ <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Help</h1>
+      <h2 class="govuk-heading-m">
+        What is GovAssure?
+      </h2>
+      <p class="govuk-body">
+       GovAssure is the new cyber security assurance approach for government that will replace the cyber security element of the organisational Security Health Check (DSHC) in 2023.
+      </p>
+      <p class="govuk-body">GovAssure uses the <a class="govuk-link" href="https://www.ncsc.gov.uk/collection/cyber-assessment-framework/introduction-to-caf" target="new">National Cyber Security Centre's Cyber Assessment Framework (CAF) (opens in a new tab)</a>
+        and meets the requirements for an objective understanding of government cyber security as set out in the
+        <a class="govuk-link" href="https://www.gov.uk/government/publications/government-cyber-security-strategy-2022-to-2030/government-cyber-security-strategy-2022-to-2030-html" target="new"> Government Cyber Security Strategy (opens in a new tab)</a>.
+        Organisations will assess critical systems against one of two CAF profiles for government, the Baseline or the Enhanced Profile. It will provide organisations and the Security Function with a more effective mechanism to understand the level of cyber resilience across government.
+
+      </p>
+
+      <h3 class="govuk-heading-m">
+        What is WebCAF?
+      </h3>
+
+      <p class="govuk-body">WebCAF is the bespoke government platform that has been developed to receive CAF submissions from organisations electronically. An organisation will provide their responses for the CAF self-assessment via WebCAF. Third-party reviewers will have access to WebCAF at a time when the department submits their completed CAF return for review.
+      </p>
+
+
+
+
+    </div>
+  </div>
+{% endblock %}

--- a/webcaf/webcaf/templates/privacy.html
+++ b/webcaf/webcaf/templates/privacy.html
@@ -1,0 +1,147 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      <h1 class="govuk-heading-l">
+        Privacy notice
+      <br><span class="govuk-body govuk-!-font-size-16  ">Last updated on 27 September 2025.
+            </span></h1>
+
+
+      <h2 class="govuk-heading-m">
+        Changes to this notice
+      </h2>
+      <p class="govuk-body">
+       We may change this privacy notice. In that case the 'last updated' date at the top of this page will also change. Any changes to this privacy notice will apply to you and your data immediately. If these changes affect how your personal data is processed, the Cabinet Office will take reasonable steps to make sure you know.
+      </p>
+      <h3 class="govuk-heading-m">
+        What data we collect
+      </h3>
+<p class="govuk-body">The personal data we collect may include:</p>
+       <ul class="govuk-list govuk-list--bullet">
+  <li>your name</li>
+  <li>the organisation you work for</li>
+  <li>your email address</li>
+  <li>your IP address</li>
+  <li>your browser and connection details</li>
+</ul>
+
+<h3 class="govuk-heading-m">
+        Why we collect this data
+      </h3>
+<p class="govuk-body">Personal data is required to provide access to the service and track the changes that people make to information within the service, and to monitor for potential security issues or incidents.
+</p>
+
+<h3 class="govuk-heading-m">
+        Recipients
+      </h3>
+<p class="govuk-body">Your personal data may be shared with security teams in your organisation in relation to security incidents, for instance if malicious behaviour is detected.
+</p>
+
+<h3 class="govuk-heading-m">
+        Retention
+      </h3>
+<p class="govuk-body">Your personal data (email and name) is retained so long as you are an active user of the system, and for at least two years for security purposes. IP addresses, browser and connection details are retained for two years for security purposes.
+</p>
+
+<h3 class="govuk-heading-m">
+        Data subject rights
+      </h3>
+<p class="govuk-body">You have the right to:
+</p>
+       <ul class="govuk-list govuk-list--bullet">
+  <li>request information about how your personal data are processed, and to request a copy of that personal data.
+</li>
+  <li>request that any incomplete personal data are completed, including by means of a supplementary statement.
+</li>
+  <li>request that your personal data are erased if there is no longer a justification for them to be processed.
+</li>
+  <li>request, in certain circumstances (for example, where accuracy is contested), that the processing of your personal data is restricted
+</li>
+  <li>object to the processing of your personal data where it is processed for direct marketing purposes.
+</li>
+<li>object to the processing of your personal data.
+</li>
+<li>withdraw consent to the processing of your personal data at any time.
+</li>
+<li>request a copy of any personal data you have provided, and for this to be provided in a structured, commonly used and machine-readable format.
+</li>
+</ul>
+
+<h3 class="govuk-heading-m">
+        International transfers
+      </h3>
+<p class="govuk-body">All processing is based in the UK.
+</p>
+
+<h3 class="govuk-heading-m">
+        Cookies
+      </h3>
+
+<p class="govuk-body">Please visit our  <a class="govuk-link" href="cookies">cookies page</a> for more information.
+</p>
+
+<h3 class="govuk-heading-m">
+        Questions and complaints
+      </h3>
+
+<p class="govuk-body">The contact details for our Data Protection Officer are:
+</p>
+
+
+<div class="govuk-inset-text">
+  <h2 class="govuk-heading-m">Contact an officer</h2>
+
+
+  <h3 class="govuk-heading-s">Email</h3>
+  <ul class="govuk-list">
+    <li><a class="govuk-link" href="#">dpo@cabinetoffice.gov.uk </a></li>
+  </ul>
+
+  <h3 class="govuk-heading-s">Address</h3>
+  <p class="govuk-body">
+    Data Protection Officer<br>
+    Cabinet Office, Room 405<Br>
+  70 Whitehall<br>
+  London<br>
+  SW1A 2AS
+  </p>
+</div>
+
+
+
+
+
+<p class="govuk-body">You may also make a complaint to the Information Commissioner, who is an independent regulator set up to uphold information rights.
+</p>
+
+
+
+<div class="govuk-inset-text">
+  <h2 class="govuk-heading-m">Contact a commissioner</h2>
+  <h3 class="govuk-heading-s">Phone</h3>
+  <ul class="govuk-list">
+    <li>Phone: 0303 123 1113</li>
+  </ul>
+
+  <h3 class="govuk-heading-s">Email</h3>
+  <ul class="govuk-list">
+    <li><a class="govuk-link" href="#">casework@ico.org.uk </a></li>
+  </ul>
+
+  <h3 class="govuk-heading-s">Address</h3>
+  <p class="govuk-body">
+    Information Commissioner’s Office<br>
+    Wycliffe House<br>
+  Water Lane<br>
+  Wilmslow<br>
+  SK9 5AF
+  </p>
+</div>
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This adds:
- New content for Privacy page
- New content for Data usage policy page
- New content for Help page
- Url for existing cookies content

It also removes the terms and conditions footer link as this is not in the prototype design