### PR TITLE
Add further error page templates

### DIFF
--- a/webcaf/webcaf/templates/404.html
+++ b/webcaf/webcaf/templates/404.html
@@ -1,24 +1,33 @@
 {% extends "base.html" %}
 {% load govuk_frontend_django %}
+{% load static %}
 
 {% block title %}Page not found{% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
+<div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Page not found</h1>
+        <p class="govuk-body">
+          There is no page at <strong>{{ request.path }}</strong>
+        </p>
+        <p class="govuk-body">This may be because:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>you typed or pasted the web address incorrectly</li>
+          <li>you followed a web address from a search engine which does not exist </li>
+          <li>you followed a web address from the GOV.UK website which does not exist </li>
+          <li>you followed a web address from an external website which does not exist </li>
 
-      <h1 class="govuk-heading-xl">
-        Page not found
-      </h1>
+        </ul>
+        <p class="govuk-body">
+          If the web address is correct or you selected a link or button, email <code class="govspeak-code">webcaf@cabinetoffice.gov.uk</code> for help.
+        </p>
 
-      <p class="govuk-body">
-        If you entered a web address, check it is correct.
-      </p>
+        <p class="govuk-body">
+          <a href="/" class="govuk-link--no-visited-state">You can go back to the service's home page</a>.
+        </p>
 
-      <p class="govuk-body">
-        You can <a class="govuk-link" href="/">go back to the service's home page</a>.
-      </p>
+
     </div>
   </div>
-
 {% endblock %}

--- a/webcaf/webcaf/templates/500.html
+++ b/webcaf/webcaf/templates/500.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load govuk_frontend_django %}
+{% load static %}
+
+{% block title %}Problem with the service{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+        <p class="govuk-body">Try again later.</p>
+        <p class="govuk-body">We did not save your answers, you must answer them again. </p>
+
+        <p class="govuk-body">
+        Email <code class="govspeak-code">webcaf@cabinetoffice.gov.uk</code> if you need support with your WebCAF self-assessment. </p>
+
+        <p class="govuk-body">
+          <a href="/" class="govuk-link--no-visited-state">You can go back to the service's home page</a>.
+        </p>
+
+
+
+    </div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This adds a new template for 500 errors and updates the content of the 404 to match prototype design