### PR TITLE
1. Add end date-time content on confirmation page and 2. Remove whitespace after ?

### DIFF
--- a/webcaf/webcaf/templates/caf/assessment/completed-confirmation.html
+++ b/webcaf/webcaf/templates/caf/assessment/completed-confirmation.html
@@ -38,9 +38,7 @@
                         </strong>
                     </div>
                     <p class="govuk-body">
-                        <a class="govuk-link" href="#">
-                            What did you think of this service?
-                        </a> (takes 30 seconds)
+                        <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
This PR contains two changes in their respective commits:

1. Added the following content as per requirements:

For your system to be assessed in GovAssure for FY 2025/26, your stage 4 review must be completed by 11:59pm on 31 March 2026.

2. Removed whitespace after the ? mark 