### PR TITLE
Creates a new permission current_user_can_view_submitted_assessment 

### DIFF
--- a/features/login_with_profile.feature
+++ b/features/login_with_profile.feature
@@ -15,4 +15,4 @@ Feature: User login with a profile
     And page contains text "<page_text>" in banner
     Examples:
       | user_name            | password | page_title         | page_text                                                                                                                                        |
-      | admin@example.gov.uk | password | My account - admin | Before starting a new CAF self-assessment, you must have a completed and signed off scoping document for stage 1 and 2 of the GovAssure process. |
+      | admin@example.gov.uk | password | My account - admin | You cannot start a new draft assessment, until your scoping document is signed off and your system has been added to WebCAF by a cyber adviser. |

--- a/tests/test_user_profile_permissions.py
+++ b/tests/test_user_profile_permissions.py
@@ -25,6 +25,7 @@ class SetupPermissionsData(BaseViewTest):
         self.create_or_skip_new_system_url = reverse("create-or-skip-new-system")
         self.create_or_skip_new_profile_url = reverse("create-or-skip-new-profile")
         self.create_a_draft_assessment_utl = reverse("create-draft-assessment")
+        self.submit_a_review_url = reverse("objective-confirmation")
         session = self.client.session
         session["current_profile_id"] = self.user_profile.id
         session.save()
@@ -133,9 +134,9 @@ class CyberAdvisorPermssionsTests(SetupPermissionsData):
         self.user_profile.role = "cyber_advisor"
         self.user_profile.save()
 
-    def test_cyber_advisor_cannot_access_create_a_draft_assessment(self):
+    def test_cyber_advisor_cannot_submit_a_review(self):
         """
         Test that a user with cyber advisor profile gets a 403 forbidden status
         """
-        # TODO - need to confirm whether the cyber advisor has any restrcitions
-        pass
+        response = self.client.get(self.submit_a_review_url)
+        self.assertEqual(response.status_code, 403)

--- a/webcaf/webcaf/templates/user-pages/my-account.html
+++ b/webcaf/webcaf/templates/user-pages/my-account.html
@@ -34,6 +34,7 @@
             </div>
             {% current_user_can_create_system current_profile as can_create_systems %}
             {% current_user_can_view_assessments current_profile as can_view_assessments %}
+            {% current_user_can_view_submitted_assessment current_profile as can_view_submittted_assessments %}
             {% if can_create_systems %}
                 <form action="{% url 'create-new-system' %}" method="GET">
                     {% csrf_token %}
@@ -78,7 +79,7 @@
                         </a>
                     </p>
                 {% endif %}
-                {% if current_user_can_submit_assessment %}
+                {% if can_view_submittted_assessments %}
                     <h3 class="govuk-heading-m">
                         Assessments sent for review
                     </h3>

--- a/webcaf/webcaf/templates/user-pages/my-account.html
+++ b/webcaf/webcaf/templates/user-pages/my-account.html
@@ -16,9 +16,8 @@
                     <div class="govuk-notification-banner__content">
 
                         <p class="govuk-notification-banner__heading">
-                            Before starting a new CAF self-assessment, you must have a completed and signed off scoping
-                            document
-                            for stage 1 and 2 of the GovAssure process.
+                            You cannot start a new draft assessment, until your scoping document is signed off
+                             and your system has been added to WebCAF by a cyber adviser.
                         </p>
 
                     </div>

--- a/webcaf/webcaf/templatetags/permission_extras.py
+++ b/webcaf/webcaf/templatetags/permission_extras.py
@@ -101,6 +101,19 @@ def current_user_can_submit_assessment(user_profile: UserProfile) -> bool:
 
 
 @register.simple_tag()
+def current_user_can_view_submitted_assessment(user_profile: UserProfile) -> bool:
+    """
+    Determines whether the current user has permission to view submitted assessments.
+
+    :param user_profile: An instance of UserProfile representing the user's profile.
+    :type user_profile: UserProfile
+    :return: A boolean indicating whether the user can view assessments.
+    :rtype: bool
+    """
+    return PermissionUtil.current_user_can_view_submitted_assessment(user_profile)
+
+
+@register.simple_tag()
 def current_user_can_view_assessments(user_profile: UserProfile) -> bool:
     """
     Determines whether the current user has permission to view assessments.

--- a/webcaf/webcaf/utils/permission.py
+++ b/webcaf/webcaf/utils/permission.py
@@ -133,6 +133,23 @@ class PermissionUtil:
             otherwise False.
         :rtype: bool
         """
+        return user_profile and user_profile.role in ["organisation_lead"]
+
+    @staticmethod
+    def current_user_can_view_submitted_assessment(user_profile: UserProfile):
+        """
+        Checks if the current user has permissions to view submitted assessments.
+
+        This method evaluates whether the given user profile corresponds to a user role
+        that is allowed to view submitted assessments. Only users with the role
+        "organisation_lead" are granted this permission.
+
+        :param user_profile: The profile of the user being checked for permission.
+        :type user_profile: UserProfile
+        :return: True if the user has the permission to submit an assessment,
+            otherwise False.
+        :rtype: bool
+        """
         return user_profile and user_profile.role in [
             "organisation_lead",
         ]


### PR DESCRIPTION
This allows us to have distinction between submitting assessments and viewing them on the my account page.

The permissions are now (with regard to submitting assessments and viewing submitted assessments)
- Org lead - can do both
- Org user - can do neither
- Cyber advisor - can do neither

it includes:
- New can_view_submitted_assessment permission tag
- Update to my account page notification banner content

have retained the extra permission as they are distinct permissions and should this need to be revised in the future it will be helpful