### PR TITLE
Standardise assessment name

### DIFF
--- a/features/login_with_profile.feature
+++ b/features/login_with_profile.feature
@@ -15,4 +15,4 @@ Feature: User login with a profile
     And page contains text "<page_text>" in banner
     Examples:
       | user_name            | password | page_title         | page_text                                                                                                                                        |
-      | admin@example.gov.uk | password | My account - admin | You cannot start a new draft assessment, until your scoping document is signed off and your system has been added to WebCAF by a cyber adviser. |
+      | admin@example.gov.uk | password | My account - admin | You cannot start a new draft self-assessment, until your scoping document is signed off and your system has been added to WebCAF by a cyber adviser. |

--- a/features/organisation_lead_create_edit_user.feature
+++ b/features/organisation_lead_create_edit_user.feature
@@ -12,7 +12,7 @@ Feature: Create and edit a new user for the organisation
     Given Think time 2 seconds
     Then they should see page title "My account - other"
     And check user is logged in against organisation "Ministry of Agriculture"
-    And a button with text "Start a draft assessment"
+    And a button with text "Start a self-assessment"
     And link with text "Your organisation details"
     And link with text "Manage users"
     When click link with text "Manage users"
@@ -36,7 +36,7 @@ Feature: Create and edit a new user for the organisation
     And User "alice@example.gov.uk" has the profile "Organisation user" assigned in "Ministry of Agriculture"
     Given Think time 2 seconds
     Then they should see page title "My account - other"
-    And a button with text "Start a draft assessment"
+    And a button with text "Start a self-assessment"
     And link with text "Your organisation details"
     And link with text "Manage users"
     When click link with text "Manage users"

--- a/features/organisation_lead_edit_organisation.feature
+++ b/features/organisation_lead_edit_organisation.feature
@@ -13,7 +13,7 @@ Feature: Organisation lead can edit an organisation's details
         Given Think time 2 seconds
         Then they should see page title "My account - other"
         And check user is logged in against organisation "Ministry of Agriculture"
-        And a button with text "Start a draft assessment"
+        And a button with text "Start a self-assessment"
         And link with text "Your organisation details"
         And link with text "Manage users"
         When click link with text "Your organisation details"

--- a/features/organisation_lead_setup_draft_assessment.feature
+++ b/features/organisation_lead_setup_draft_assessment.feature
@@ -7,7 +7,7 @@ Feature: Organisation lead can edit an organisation's details
     And User "other@example.gov.uk" has the profile "Organisation lead" assigned in "Ministry of Agriculture"
     And the application is running
     And the user logs in with username  "other@example.gov.uk" and password "password"
-    And click button with text "Start a draft assessment"
+    And click button with text "Start a self-assessment"
     And click link with text "Provide system details"
     And select select box with value "System 2"
     And click button with text "Save and continue"

--- a/features/organisation_lead_submit_assessment.feature
+++ b/features/organisation_lead_submit_assessment.feature
@@ -12,7 +12,7 @@ Feature: Organisation lead can submit assessment
   Scenario: Organisation lead can can submit a completed assessment
     Given Think time 2 seconds
     Then they should see page title "My account - other"
-    And click link with text "View 1 draft assessment"
+    And click link with text "View 1 draft self-assessment"
     And click link in table row containing value "System 1" with text "View"
     And click link with text "Complete the full self-assessment"
     And click button with text "Save and send for review"

--- a/features/organisation_user_actions.feature
+++ b/features/organisation_user_actions.feature
@@ -12,7 +12,7 @@ Feature: Organisation user filling assessments
   Scenario: Organisation user complete assessment process
     Given Think time 2 seconds
     Then they should see page title "My account - alice"
-    And click link with text "View 1 draft assessment"
+    And click link with text "View 1 draft self-assessment"
     And page has heading "Your draft self-assessments"
     And click link in table row containing value "System 1" with text "View"
     Then page has heading "Submit a WebCAF self-assessment"
@@ -105,5 +105,5 @@ Feature: Organisation user filling assessments
     And Fill outcome confirm status "Achieved" with "This is a test outcome comment"
     And Fill outcome "D2.b Using Incidents to Drive Improvements " with "achieved, partially-achieved, not-achieved" with "all,none,none"
     And Fill outcome confirm status "Achieved" with "This is a test outcome comment"
-    Then click button with text "Back to draft assessment"
+    Then click button with text "Back to draft self-assessment"
     And confirm the current assessment has expected data "alice_completed_assessment.json"

--- a/tests/test_caf32_router.py
+++ b/tests/test_caf32_router.py
@@ -137,7 +137,7 @@ class TestCAF32Router(unittest.TestCase):
         context = view.get_context_data()
         breadcrumbs = context.get("breadcrumbs")
         self.assertEqual(breadcrumbs[-2]["text"], "My account")
-        self.assertEqual(breadcrumbs[-1]["text"], "Edit draft assessment")
+        self.assertEqual(breadcrumbs[-1]["text"], "Edit draft self-assessment")
 
     def test_outcome_breadcrumbs(self):
         factory = RequestFactory()
@@ -160,7 +160,7 @@ class TestCAF32Router(unittest.TestCase):
                 context = view.get_context_data()
         breadcrumbs = context.get("breadcrumbs")
         self.assertEqual(breadcrumbs[0]["text"], "My account")
-        self.assertEqual(breadcrumbs[1]["text"], "Edit draft assessment")
+        self.assertEqual(breadcrumbs[1]["text"], "Edit draft self-assessment")
         self.assertEqual(breadcrumbs[2]["text"], "Objective A - Detecting cyber security events")
         self.assertEqual(breadcrumbs[3]["text"], "Objective A1.a - Monitoring Coverage")
 

--- a/webcaf/webcaf/models.py
+++ b/webcaf/webcaf/models.py
@@ -263,8 +263,8 @@ class UserProfile(models.Model):
         "cyber_advisor": """On this page you can add new systems, modify existing systems and manage users within an
                     organisation.""",
         "organisation_lead": """On this page you can manage users within an
-                    organisation, continue a draft assessment and view assessments already sent for review.""",
-        "organisation_user": "On this page you can continue a draft assessment and view assessments already sent for review.",
+                    organisation, continue a draft self-assessment and view self-assessments already sent for review.""",
+        "organisation_user": "On this page you can continue a draft self-assessment and view self-assessments already sent for review.",
     }
     ROLE_CHOICES = [
         ("cyber_advisor", "GDS cyber advisor"),

--- a/webcaf/webcaf/templates/assessment-profile.html
+++ b/webcaf/webcaf/templates/assessment-profile.html
@@ -23,7 +23,7 @@
                     <fieldset class="govuk-fieldset" aria-describedby="cafprofile-hint">
                         <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
                             <h1 class="govuk-fieldset__heading">
-                                Choose a profile for this assessment
+                                Choose a profile for this self-assessment
                             </h1>
                         </legend>
                         <div id="cafprofile-hint" class="govuk-hint">

--- a/webcaf/webcaf/templates/caf/assessment/choose-review-type.html
+++ b/webcaf/webcaf/templates/caf/assessment/choose-review-type.html
@@ -3,7 +3,7 @@
 {% load csp %}
 {% load form_extras %}
 
-{% block title %}Choose review type for your self assessment{% endblock %}
+{% block title %}Choose review type for your self-assessment{% endblock %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">

--- a/webcaf/webcaf/templates/caf/assessment/completed-confirmation.html
+++ b/webcaf/webcaf/templates/caf/assessment/completed-confirmation.html
@@ -20,7 +20,7 @@
                         </div>
                     </div>
                     <p class="govuk-body">
-                        Your CAF self-assessment has been shared with the GovAssure team.
+                        Your self-assessment has been shared with the GovAssure team.
                     </p>
                     <h2 class="govuk-heading-m">
                         What happens next

--- a/webcaf/webcaf/templates/caf/assessment/draft-assessment.html
+++ b/webcaf/webcaf/templates/caf/assessment/draft-assessment.html
@@ -3,7 +3,7 @@
 {% load csp %}
 {% load form_extras %}
 
-{% block title %}Manage Assessment - {{ user.first_name }} {% endblock %}
+{% block title %}Manage self-assessment - {{ user.first_name }} {% endblock %}
 
 {% block with_progress %}
     {% include "caf/partials/progress_indicator.html" with assessment=assessment %}

--- a/webcaf/webcaf/templates/caf/confirmation.html
+++ b/webcaf/webcaf/templates/caf/confirmation.html
@@ -59,7 +59,7 @@
                 </span>
                                             </summary>
                                             <div class="govuk-details__text">
-                                                GovAssure stage 4 assessments are reviewed against the contributing
+                                                GovAssure stage 4 self-assessments are reviewed against the contributing
                                                 outcomes. <br><br>
                                                 While the focus is on meeting the contributing outcome, any gaps or
                                                 limitations in the cyber security measures for the contributing outcome

--- a/webcaf/webcaf/templates/caf/objective.html
+++ b/webcaf/webcaf/templates/caf/objective.html
@@ -62,7 +62,7 @@
                       action="{% url 'edit-draft-assessment' assessment_id=assessment.id %}">
                     <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button"
                             data-govuk-button-init="">
-                        Back to draft assessment
+                        Back to draft self-assessment
                     </button>
                 </form>
             {% endif %}

--- a/webcaf/webcaf/templates/caf/partials/progress_indicator.html
+++ b/webcaf/webcaf/templates/caf/partials/progress_indicator.html
@@ -7,7 +7,7 @@
   {% generate_assessment_progress_indicators assessment as progress_indicators %}
 {% endif %}
 
-<div class="progress-container" role="region" aria-label="Assessment Progress">
+<div class="progress-container" role="region" aria-label="Self-assessment progress">
   {% if principle_id %}
   <p class="govuk-hint">Principle {{progress_indicators.question_number}} of {{progress_indicators.principles_in_section}}<br><strong>Principle: {{ progress_indicators.principle }} {{ progress_indicators.principle_name }}</strong>
     <br></p>

--- a/webcaf/webcaf/templates/index.html
+++ b/webcaf/webcaf/templates/index.html
@@ -26,14 +26,14 @@
             </strong>
             </div>
             <p class="govuk-body">You must create a separate repository to store evidence securely and share links to it. The assessor or peer reviewer will need access to this repository in Stage 4 in order to check your self-assessment responses.</p>
-            <p class="govuk-body">There is more about creating an evidence repository at <a class="govuk-link" href="https://www.security.gov.uk/policy-and-guidance/govassure/stage-3-self-assessment/" target="_blank">Stage 3 Provide your CAF self-assessment</a></p>
+            <p class="govuk-body">There is more about creating an evidence repository at <a class="govuk-link" href="https://www.security.gov.uk/policy-and-guidance/govassure/stage-3-self-assessment/" target="_blank">Stage 3 Provide your self-assessment</a></p>
             <h2 class="govuk-heading-m">Before you start
             </h2>
             <p class="govuk-body">You must have completed stage 1 and stage 2 of GovAssure. This means you will have:</p>
 
             <ul class="govuk-list govuk-list--bullet">
                 <li>completed your organisation’s scoping document </li>
-                <li>identified all your systems for assessment </li>
+                <li>identified all your systems for self-assessment </li>
                 <li>chosen the the CAF profile of each system being assessed (baseline or enhanced)</li>
                 <li>nominated a GovAssure lead in your organisation, to complete the self-assessment</li>
                 <li>created a repository for your evidence</li>

--- a/webcaf/webcaf/templates/system/systems.html
+++ b/webcaf/webcaf/templates/system/systems.html
@@ -12,7 +12,7 @@
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header">System name</th>
-                    <th scope="col" class="govuk-table__header">Assessment status</th>
+                    <th scope="col" class="govuk-table__header">Self-assessment status</th>
                 </tr>
                 </thead>
                 <tbody class="govuk-table__body">
@@ -25,7 +25,7 @@
                         </th>
                         <td class="govuk-table__cell">
                             {% if system.assessments.all|length == 0 %}
-                                No assessment started
+                                No self-assessment started
                             {% else %}
                                 {% with system.assessments.all|slice:"-1:" as last_item %}
                                     {{ last_item.0.status|capfirst }}

--- a/webcaf/webcaf/templates/user-pages/draft-assessments.html
+++ b/webcaf/webcaf/templates/user-pages/draft-assessments.html
@@ -8,7 +8,7 @@
                 Your draft self-assessments
             </h1>
             <table class="govuk-table">
-                <caption class="govuk-table__caption govuk-table__caption--m">Continue a draft assessment</caption>
+                <caption class="govuk-table__caption govuk-table__caption--m">Continue a draft self-assessment</caption>
                 <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                     <th scope="col" class="govuk-table__header">System name</th>

--- a/webcaf/webcaf/templates/user-pages/my-account.html
+++ b/webcaf/webcaf/templates/user-pages/my-account.html
@@ -16,7 +16,7 @@
                     <div class="govuk-notification-banner__content">
 
                         <p class="govuk-notification-banner__heading">
-                            You cannot start a new draft assessment, until your scoping document is signed off
+                            You cannot start a new draft self-assessment, until your scoping document is signed off
                              and your system has been added to WebCAF by a cyber adviser.
                         </p>
 
@@ -53,36 +53,36 @@
                 <form action="{% url 'create-draft-assessment' %}" method="GET">
                     {% csrf_token %}
                     <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                        Start a draft assessment
+                        Start a self-assessment
                     </button>
                 </form>
             {% endif %}
             {% if can_view_assessments %}
                 <h3 class="govuk-heading-m govuk-!-margin-bottom-2">
-                    Continue a draft assessment
+                    Continue a self-assessment
                 </h3>
                 {% if not draft_systems %}
-                    <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">You don't have any draft assessments.
+                    <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">You don't have any self-assessments.
                     </p>
                 {% else %}
                     {% if completed_assessment_count > 0 %}
                         <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">
                             You have {{ completed_assessment_count }} draft
-                            assessment{{ completed_assessment_count  | pluralize }} ready to
+                            self-assessment{{ completed_assessment_count  | pluralize }} ready to
                             send
                         </p>
                     {% endif %}
                     <p class="govuk-body" title="View {{ draft_systems| length }} draft assessment(s)">
                         <a href="{% url 'view-draft-assessments' %}" class="govuk-link govuk-link--no-visited-state">
-                            View {{ draft_systems| length }} draft assessment{{ draft_systems | length | pluralize }}
+                            View {{ draft_systems| length }} draft self-assessment{{ draft_systems | length | pluralize }}
                         </a>
                     </p>
                 {% endif %}
                 {% if can_view_submittted_assessments %}
                     <h3 class="govuk-heading-m">
-                        Assessments sent for review
+                        Self-assessments sent for review
                     </h3>
-                    <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">You didn't submit an assessment.
+                    <p class="govuk-body govuk-!-margin-bottom-2 govuk-hint">You didn't submit a self-assessment.
                 {% endif %}
             {% endif %}
         </div>

--- a/webcaf/webcaf/views/assesment.py
+++ b/webcaf/webcaf/views/assesment.py
@@ -134,7 +134,7 @@ class EditAssessmentView(LoginRequiredMixin, FormView):
             return reverse("edit-draft-assessment", kwargs={"assessment_id": self.kwargs["assessment_id"]})
 
     def breadcrumbs(self, assessment_id: int):
-        return [{"url": "#", "text": "Edit draft assessment"}]
+        return [{"url": "#", "text": "Edit draft self-assessment"}]
 
 
 class AssessmentProfileForm(ModelForm):
@@ -234,7 +234,7 @@ class EditAssessmentProfileView(EditAssessmentView):
                         "assessment_id": assessment_id,
                     },
                 ),
-                "text": "Edit draft assessment",
+                "text": "Edit draft self-assessment",
             },
             {"url": "#", "text": "Choose Profile"},
         ]
@@ -273,7 +273,7 @@ class EditAssessmentSystemView(EditAssessmentView):
                         "assessment_id": assessment_id,
                     },
                 ),
-                "text": "Edit draft assessment",
+                "text": "Edit draft self-assessment",
             },
             {"url": "#", "text": "Choose System"},
         ]
@@ -509,7 +509,7 @@ class EditAssessmentReviewTypeView(EditAssessmentView):
                         "assessment_id": assessment_id,
                     },
                 ),
-                "text": "Edit draft assessment",
+                "text": "Edit draft self-assessment",
             },
             {"url": "#", "text": "Choose review type"},
         ]

--- a/webcaf/webcaf/views/general.py
+++ b/webcaf/webcaf/views/general.py
@@ -53,7 +53,7 @@ class FormViewWithBreadcrumbs(FormView):
         """
         return [
             {
-                "text": "Edit draft assessment",
+                "text": "Edit draft self-assessment",
                 "url": reverse_lazy(
                     "edit-draft-assessment",
                     kwargs={"assessment_id": self.request.session["draft_assessment"]["assessment_id"]},


### PR DESCRIPTION
There were inconsistencies to how the self-assessment was worded
across the application. CAF assessment, assessment, etc.

This commit ensures the term self-assessment is used consistently
across all pages