### PR TITLE
Restrict vulnerable litellm versions in pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2888,4 +2888,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4"
-content-hash = "e8fabddfeecfb76eb3df50e11c4b9f6a308494cfe4493bcf0af1e00869972a75"
+content-hash = "4d7f0894d3b2283ac9b52c8826b1a1824dc9eec5c96f16973c7e0a8805b1618b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,8 @@ django_settings_module = "webcaf.settings"
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+
+[tool.poetry.dependencies]
+# Disallow the problamatic versions that have the vulnerability
+litellm = "!=1.82.7, !=1.82.8"


### PR DESCRIPTION
- Added exclusive filtering out of the 1.82.7 and 1.82.8 litellm versions from being installed. This is to prevent a known vulnerability from being exploited.