### PR TITLE
Feature/send email to assessor upon assessment submission

### DIFF
--- a/tests/test_notification.py
+++ b/tests/test_notification.py
@@ -1,0 +1,124 @@
+from unittest.mock import call, patch
+
+from django.test import TestCase, override_settings
+
+from webcaf.webcaf.notification import send_notify_email
+
+
+@override_settings(NOTIFY_API_KEY="test-api-key")  # pragma: allowlist secret
+class SendNotifyEmailTest(TestCase):
+    def setUp(self):
+        self.personalisation = {"first_name": "Alice", "link": "https://example.com"}
+        self.template_id = "template-abc-123"
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_sends_email_to_single_address(self, mock_client_cls, mock_sleep):
+        mock_client = mock_client_cls.return_value
+        send_notify_email(["alice@example.com"], self.personalisation, self.template_id)
+        mock_client.send_email_notification.assert_called_once_with(
+            email_address="alice@example.com",
+            template_id=self.template_id,
+            personalisation=self.personalisation,
+        )
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_sends_to_all_addresses(self, mock_client_cls, mock_sleep):
+        mock_client = mock_client_cls.return_value
+        send_notify_email(["a@x.com", "b@x.com", "c@x.com"], self.personalisation, self.template_id)
+        sent_to = {c.kwargs["email_address"] for c in mock_client.send_email_notification.call_args_list}
+        self.assertEqual(sent_to, {"a@x.com", "b@x.com", "c@x.com"})
+        self.assertEqual(mock_client.send_email_notification.call_count, 3)
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_deduplicates_email_addresses(self, mock_client_cls, mock_sleep):
+        mock_client = mock_client_cls.return_value
+        send_notify_email(["same@x.com", "same@x.com", "same@x.com"], self.personalisation, self.template_id)
+        self.assertEqual(mock_client.send_email_notification.call_count, 1)
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_initialises_client_with_api_key(self, mock_client_cls, mock_sleep):
+        send_notify_email(["a@x.com"], self.personalisation, self.template_id)
+        mock_client_cls.assert_called_once_with("test-api-key")
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_passes_personalisation_and_template_id(self, mock_client_cls, mock_sleep):
+        mock_client = mock_client_cls.return_value
+        personalisation = {"key": "value", "other": "data"}
+        send_notify_email(["a@x.com"], personalisation, "custom-template")
+        mock_client.send_email_notification.assert_called_once_with(
+            email_address="a@x.com",
+            template_id="custom-template",
+            personalisation=personalisation,
+        )
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_no_sends_for_empty_list(self, mock_client_cls, mock_sleep):
+        mock_client = mock_client_cls.return_value
+        send_notify_email([], self.personalisation, self.template_id)
+        mock_client.send_email_notification.assert_not_called()
+        mock_sleep.assert_not_called()
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_sleeps_between_sends(self, mock_client_cls, mock_sleep):
+        """Pauses for retry_delay seconds after each successful send."""
+        send_notify_email(["a@x.com", "b@x.com"], {}, self.template_id, retry_delay=0.25)
+        inter_send_sleeps = [c for c in mock_sleep.call_args_list if c == call(0.25)]
+        self.assertEqual(len(inter_send_sleeps), 2)
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_retries_on_transient_failure_and_succeeds(self, mock_client_cls, mock_sleep):
+        """A single transient error is retried and the send ultimately succeeds."""
+        mock_client = mock_client_cls.return_value
+        mock_client.send_email_notification.side_effect = [Exception("timeout"), None]
+        send_notify_email(["a@x.com"], self.personalisation, self.template_id, max_retries=1, retry_delay=0)
+        self.assertEqual(mock_client.send_email_notification.call_count, 2)
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_raises_immediately_when_max_retries_zero(self, mock_client_cls, mock_sleep):
+        """With max_retries=0, the first failure raises without any retry sleep."""
+        mock_client = mock_client_cls.return_value
+        mock_client.send_email_notification.side_effect = Exception("server error")
+        with self.assertRaisesRegex(Exception, "server error"):
+            send_notify_email(["a@x.com"], self.personalisation, self.template_id, max_retries=0)
+        self.assertEqual(mock_client.send_email_notification.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_retry_sleep_uses_backoff_delay(self, mock_client_cls, mock_sleep):
+        """Retry sleeps for retry_delay * (retry_count + 1) seconds before the next attempt."""
+        mock_client = mock_client_cls.return_value
+        mock_client.send_email_notification.side_effect = [Exception("e"), None]
+        send_notify_email(["a@x.com"], {}, self.template_id, max_retries=2, retry_delay=1.0)
+        # retry_count starts at 0 and is never incremented, so delay is always 1.0 * (0 + 1)
+        self.assertIn(call(1.0), mock_sleep.call_args_list)
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_logs_warning_on_retry(self, mock_client_cls, mock_sleep):
+        """A WARNING is emitted for each failed attempt, including the error message."""
+        mock_client = mock_client_cls.return_value
+        mock_client.send_email_notification.side_effect = [Exception("network error"), None]
+        with self.assertLogs("webcaf.webcaf.notification", level="WARNING") as log:
+            send_notify_email(["a@x.com"], {}, self.template_id, max_retries=1, retry_delay=0)
+        self.assertTrue(any("network error" in msg for msg in log.output))
+
+    @patch("webcaf.webcaf.notification.time.sleep")
+    @patch("webcaf.webcaf.notification.NotificationsAPIClient")
+    def test_custom_retry_delay_respected(self, mock_client_cls, mock_sleep):
+        """Custom retry_delay is used for both the inter-send pause and backoff calculation."""
+        mock_client = mock_client_cls.return_value
+        mock_client.send_email_notification.side_effect = [Exception("e"), None]
+        send_notify_email(["a@x.com"], {}, self.template_id, max_retries=1, retry_delay=2.0)
+        # Retry backoff: 2.0 * (0 + 1) = 2.0; inter-send pause: 2.0
+        sleep_values = [c.args[0] for c in mock_sleep.call_args_list]
+        self.assertTrue(all(v == 2.0 for v in sleep_values))

--- a/webcaf/webcaf/notification.py
+++ b/webcaf/webcaf/notification.py
@@ -1,12 +1,26 @@
+import logging
+import time
+
 from django.conf import settings
 from notifications_python_client import NotificationsAPIClient
 
+logger = logging.getLogger(__name__)
 
-def send_notify_email(email_addresses: list[str], personalisation_data: dict[str, str], template_id: str | None = None):
+
+def send_notify_email(
+    email_addresses: list[str],
+    personalisation_data: dict[str, str],
+    template_id: str,
+    max_retries: int = 5,
+    retry_delay: float = 0.1,
+):
     """
     Sends an email notification using the Gov Notify service with the specified
     template and personalisation data. It utilizes the `NotificationsAPIClient`
     to send the email to the designated recipient.
+    :param retry_delay: Retry delay. Each retry will be delayed by
+    retry_delay * retry (1-max_retries) seconds
+    :param max_retries: How many times to retry before giving up
     :param email_addresses: A list of email addresses to send the notification to.
     :param personalisation_data: A dictionary containing key-value pairs for
         personalisation fields to be inserted into the email template.
@@ -16,9 +30,27 @@ def send_notify_email(email_addresses: list[str], personalisation_data: dict[str
     :raises Exception: If an error occurs during the notification process.
     """
     notify_client = NotificationsAPIClient(settings.NOTIFY_API_KEY)
-    # Send the token using the Gov Notify template
-    notify_client.send_email_notification(
-        email_address=",".join(email_addresses),
-        template_id=template_id,
-        personalisation=personalisation_data,
-    )
+    retry = True
+    for email_address in set(email_addresses):
+        # Send the token using the Gov Notify template
+        retry_count = 0
+        while retry:
+            try:
+                notify_client.send_email_notification(
+                    # You can give only 1 email address per call
+                    # https://docs.notifications.service.gov.uk/python.html#email-address-required
+                    email_address=email_address,
+                    template_id=template_id,
+                    personalisation=personalisation_data,
+                )
+                break
+            except Exception as e:
+                if retry_count < max_retries:
+                    delay_seconds = retry_delay * (retry_count + 1)
+                    logger.warning(f"Failed to send email {e} retry after {delay_seconds} seconds")
+                    time.sleep(delay_seconds)  # backoff before retry
+                    retry_count += 1
+                else:
+                    raise
+        # pause between each send
+        time.sleep(retry_delay)

--- a/webcaf/webcaf/views/sections.py
+++ b/webcaf/webcaf/views/sections.py
@@ -83,10 +83,12 @@ class SectionConfirmationView(UserRoleCheckMixin, FormView):
                     # Initiate the review
                     if assessment.review_type in ["independent", "peer_review"]:
                         review, _ = Review.objects.get_or_create(assessment=assessment)
-                        self.logger.info(f"Initiating review for {assessment.id} by {self.request.user.pk} {review.id}")
+                        self.logger.info(
+                            f"Initiating review for {assessment.reference} by user {self.request.user.pk} review ref={review.reference}"
+                        )
                     else:
                         self.logger.info(
-                            f"No review initiated for {assessment.id} by {self.request.user.pk} as review type is not independent or peer review"
+                            f"No review initiated for {assessment.reference} by user {self.request.user.pk} as review type is not independent or peer review"
                         )
                     self.logger.info(
                         f"Assessment {assessment.id} reference {assessment.reference} submitted"
@@ -94,17 +96,17 @@ class SectionConfirmationView(UserRoleCheckMixin, FormView):
                     )
                     self._send_emails(assessment, uk_tz)
                 else:
-                    self.logger.info(f"Assessment {assessment.id} already submitted")
+                    self.logger.info(f"Assessment {assessment.reference} already submitted")
                 return redirect(reverse("show-submission-confirmation"))
             else:
                 # User has not completed all objectives and should not have reached this page
                 self.logger.error(
                     mask_email(
-                        f"User {self.request.user.pk} has not completed all objectives, but tried to submit {assessment.id}"
+                        f"User {self.request.user.pk} has not completed all objectives, but tried to submit {assessment.reference}"
                     )
                 )
         else:
-            self.logger.info(f"No assessment found in session {self.request.user.pk}")
+            self.logger.info(f"No assessment found in session for user {self.request.user.pk}")
 
         return redirect(reverse("my-account"))
 
@@ -113,7 +115,7 @@ class SectionConfirmationView(UserRoleCheckMixin, FormView):
         if settings.NOTIFY_CONFIRMATION_TEMPLATE_ID:
             self.logger.info(
                 mask_email(
-                    f"Sending confirmation email for {assessment.id} to {self.request.user.pk} "
+                    f"Sending confirmation email for assessment {assessment.reference} to user {self.request.user.pk} - "
                     f"{self.request.user.email}"  # type: ignore[union-attr]
                 )
             )
@@ -140,7 +142,9 @@ class SectionConfirmationView(UserRoleCheckMixin, FormView):
             addresses = []
             for profile in profile_list:
                 self.logger.info(
-                    mask_email(f"Sending assessment ready email for {assessment.id} to {profile.user.email}")
+                    mask_email(
+                        f"Sending assessment ready email for assessment {assessment.reference} to {profile.user.email}"
+                    )
                 )
                 if profile.user.email:
                     addresses.append(profile.user.email)
@@ -213,7 +217,7 @@ class SectionConfirmationView(UserRoleCheckMixin, FormView):
         """
         try:
             send_notify_email(
-                list(set(email_addresses)),
+                email_addresses,
                 data,
                 template_id,
             )


### PR DESCRIPTION
This contains:
 - logging improvements as the existing text was not that useful and difficult to understand
 - corrected a mistake in the notify api call (we should only be calling the api with a single email address)