### PR TITLE
Data export bug fixes and updates

### DIFF
--- a/tests/test_data_export_command.py
+++ b/tests/test_data_export_command.py
@@ -129,11 +129,12 @@ class TestExportReviews(TestCase):
                                 "achieved_A1.a.1_comment": "Strong evidence",
                                 "not-achieved_A1.a.2": "no",
                             },
+                            "recommendations": [{"text": "Rec 1", "title": "Title 1"}],
                         }
                     },
                     "B": {"B1.a": {"review_data": {"review_decision": "achieved"}}},
                     "C": {
-                        "C1.a": {},
+                        "C1.a": {"recommendations": [{"text": "Rec 2", "title": "Title 2"}]},
                         "objective-areas-of-improvement": "everything",
                         "objective-areas-of-good-practice": "nothing",
                     },
@@ -192,7 +193,14 @@ class TestExportReviews(TestCase):
                         {
                             "outcome_id": "A1.a",
                             "outcome_min_profile_requirement": "Achieved",
-                            "recommendations": [],
+                            "recommendations": [
+                                {
+                                    "recommendation_id": "REC-A1A1",
+                                    "recommendation_text": "Rec 1",
+                                    "risk_text": "Title 1",
+                                    "priority_recommendation": False,
+                                }
+                            ],
                             "review_decision": "Achieved",
                             "review_profile_met": "Met",
                             "review_comment": "Well implemented",
@@ -223,7 +231,14 @@ class TestExportReviews(TestCase):
                         {
                             "outcome_id": "C1.a",
                             "outcome_min_profile_requirement": "",
-                            "recommendations": [],
+                            "recommendations": [
+                                {
+                                    "recommendation_id": "REC-C1A1",
+                                    "recommendation_text": "Rec 2",
+                                    "risk_text": "Title 2",
+                                    "priority_recommendation": "",
+                                }
+                            ],
                             "review_decision": "N/A",
                             "review_profile_met": "",  # N/A → callback not called → ""
                             "review_comment": "",
@@ -249,7 +264,7 @@ class TestExportReviews(TestCase):
                         "company_name": None,
                         "quality_self_assessment": None,
                         "review_method": None,
-                        "review_period": {},
+                        "review_period": {"end_date": None, "start_date": None},
                     },
                     "review_commentary": {
                         "objective_level": [
@@ -405,6 +420,7 @@ class TestExportReviewsIntegration(TestCase):
                                 "not-achieved_A1.a.3_comment": "",
                                 "not-achieved_A1.a.4_comment": "",
                             },
+                            "recommendations": [{"text": "Priority Rec", "title": "Priority Title"}],
                         },
                         "A1.b": {
                             "review_data": {
@@ -524,6 +540,18 @@ class TestExportReviewsIntegration(TestCase):
         # "Not achieved" (score 1) < "Achieved" (score 3) → "Not met"
         self.assertEqual("Not met", a1a["review_profile_met"])
 
+        self.assertEqual(
+            [
+                {
+                    "recommendation_id": "REC-A1A1",
+                    "recommendation_text": "Priority Rec",
+                    "risk_text": "Priority Title",
+                    "priority_recommendation": True,
+                }
+            ],
+            a1a["recommendations"],
+        )
+
         self.assertEqual(_LOREM_IPSUM, a1a["review_comment"])
 
         # Indicators: comment keys stripped; "yes" → True, "no" → False
@@ -551,6 +579,18 @@ class TestExportReviewsIntegration(TestCase):
         # review_profile_met: CAF 3.2 A1.b baseline min requirement = "Achieved";
         # "Achieved" (score 3) >= "Achieved" (score 3) → "Met"
         self.assertEqual("Met", a1b["review_profile_met"])
+
+        self.assertEqual(
+            [
+                {
+                    "recommendation_id": "REC-A1B1",
+                    "recommendation_text": "Recommendation text",
+                    "risk_text": "recommendation title",
+                    "priority_recommendation": False,
+                }
+            ],
+            a1b["recommendations"],
+        )
 
         self.assertEqual("retretr", a1b["review_comment"])
 
@@ -664,13 +704,13 @@ class TestExportSystemsIntegration(TestCase):
                 # CharField choice — full display label, no split
                 "system_type": "directly_delivers_public_services",
                 # MultiSelectField single values — split produces a one-element list
-                "hosting_type": ["hosted_on_cloud"],
+                "hosting_type": "hosted_on_cloud",
                 "corporate_services": ["payroll"],
-                "system_owner": ["owned_by_organisation_being_assessed"],
+                "system_owner": "owned_by_organisation_being_assessed",
                 "organisation_id": self.child_org.id,
                 "system_id": self.system.id,
                 # Mapping the last assessed values in to something usable in analasys
-                "last_assessed": ["23/24"],
+                "last_assessed": "assessed_in_2324",
                 "legacy_system_id": None,
             },
             system_body,

--- a/webcaf/webcaf/management/commands/export_data.py
+++ b/webcaf/webcaf/management/commands/export_data.py
@@ -285,39 +285,15 @@ class Command(BaseCommand):
                             {
                                 "system_name": system.name,
                                 "system_type": system.system_type,
-                                "hosting_type": system.hosting_type,
+                                "hosting_type": system.hosting_type[0] if system.hosting_type[0] else None,
                                 "corporate_services": system.corporate_services,
-                                "system_owner": system.system_owner,
+                                "system_owner": system.system_owner[0] if system.system_owner[0] else None,
                                 "organisation_id": system.organisation.id,
                                 "system_id": system.id,
-                                "last_assessed": _transform_last_assessed(system.last_assessed),
+                                "last_assessed": system.last_assessed,
                                 "app_version": "webcaf-2",
                                 "legacy_system_id": None,
                             }
                         )
                     ),
                 )
-
-
-# Mapping from ``System.last_assessed`` database values to the short
-# period labels used in the analytics export.
-_LAST_ASSESSED_TO_PERIODS: dict[str, list[str]] = {
-    "assessed_in_2324": ["23/24"],
-    "assessed_in_2425": ["24/25"],
-    "assessed_in_2324_and_2425": ["23/24", "24/25"],
-}
-
-
-def _transform_last_assessed(last_assessed: str | None) -> list[str]:
-    """Map a ``last_assessed`` database value to short period labels.
-
-    Args:
-        last_assessed: Raw value from the ``System.last_assessed`` field.
-
-    Returns:
-        A list of period strings (e.g. ``["23/24"]``), or an empty list
-        if the value is falsy or unrecognised.
-    """
-    if not last_assessed:
-        return []
-    return list(_LAST_ASSESSED_TO_PERIODS.get(last_assessed, []))

--- a/webcaf/webcaf/utils/data_analysis.py
+++ b/webcaf/webcaf/utils/data_analysis.py
@@ -260,7 +260,9 @@ def transform_review(
         "app_version": metadata["app_version"],
         "assessment_id": metadata["assessment_id"],
         "review_details": {
-            "review_period": additional_information.get("iar_period", {}),
+            # Need to put the structure correct so the Athena tables do not get confused
+            # when generating the schema
+            "review_period": additional_information.get("iar_period", {"end_date": None, "start_date": None}),
             "company_name": additional_information.get("company_details", {}).get("company_name"),
             "review_method": additional_information.get("review_method"),
             "quality_self_assessment": additional_information.get("quality_of_evidence"),
@@ -311,7 +313,7 @@ def _build_recommendations(
                 "recommendation_id": f"{rec_id_prefix}{idx + 1}",
                 "recommendation_text": recommendation.get("text"),
                 "risk_text": recommendation.get("title"),
-                "priority_recommendation": (review_profile_met.lower() != "yes" if review_profile_met else ""),
+                "priority_recommendation": (review_profile_met.lower() != "met" if review_profile_met else ""),
             }
         )
 

--- a/webcaf/webcaf/utils/data_migration/assessment_transformer.py
+++ b/webcaf/webcaf/utils/data_migration/assessment_transformer.py
@@ -29,7 +29,9 @@ def transform_assessment_v1_to_v2(
     version_key = assessment_meta.get("assessment_version_id", "unknown")
 
     # Parse old assessment data
-    group_comments, outcomes, supplementary_questions = _parse_old_assessment_data(old_assessment_data)
+    group_comments, group_assessor_comments, outcomes, supplementary_questions = _parse_old_assessment_data(
+        old_assessment_data
+    )
 
     # Process all outcomes
     objectives = definition_structure[version_key].get("objectives", {})
@@ -147,9 +149,10 @@ def _process_indicators_by_type(
 
 def _parse_old_assessment_data(
     old_assessment_data: list[dict[str, Any]]
-) -> tuple[dict[str, list], dict[str, list], dict[str, list]]:
+) -> tuple[dict[str, list], dict[str, list], dict[str, list], dict[str, list]]:
     """Parse old assessment data into group comments, outcomes, and supplementary questions."""
     group_comments = defaultdict(list)
+    group_review_comments = defaultdict(list)
     outcomes = defaultdict(list)
     supplementary_questions = defaultdict(list)
 
@@ -157,9 +160,11 @@ def _parse_old_assessment_data(
         key = entry.get("key")
         group_key = entry.get("group_key")
         org_comment = entry.get("org_comment")
-
+        assessor_comment = entry.get("assessor_comment")
         if group_key and org_comment:
             group_comments[group_key].append(org_comment)
+        if group_key and assessor_comment:
+            group_review_comments[group_key].append(assessor_comment)
 
         # Outcome keys (e.g., A1.a) or Indicator keys (e.g., A1.a.1)
         if key and key.count(".") == 1:
@@ -171,7 +176,7 @@ def _parse_old_assessment_data(
             outcome_key = ".".join(key.split(".")[:2])
             outcomes[outcome_key].append(("indicator", entry))
 
-    return group_comments, outcomes, supplementary_questions
+    return group_comments, group_review_comments, outcomes, supplementary_questions
 
 
 def _get_indicator_comment(entry: dict[str, Any], group_comments: dict[str, list]) -> str:

--- a/webcaf/webcaf/utils/data_migration/migrate_data.py
+++ b/webcaf/webcaf/utils/data_migration/migrate_data.py
@@ -288,16 +288,27 @@ def _write_organisations_data(organisations: dict[str, Any]) -> None:
             )
 
 
-def _write_systems_data(systems: dict[str, Any]) -> None:
+def _write_systems_data(
+    systems: dict[str, Any], organisations: dict[str, Any], assessments_metadata: dict[str, Any]
+) -> None:
     """Write systems data to individual files."""
     for system_id, system_data in systems.items():
         output_file_path = Path(__file__).parent / TRANSFORMED_DATA_DIR / SYSTEMS_OUTPUT_DIR / f"{system_id}.json"
         with open(output_file_path, "w") as output_file:
+            matched_assessment = next(
+                filter(
+                    lambda assessment_data: assessment_data["hashed_system_id"] == system_id,
+                    assessments_metadata.values(),
+                )
+            )
+            hashed_organisation_id = matched_assessment["hashed_organisation_id"]
+            organisation = organisations.get(hashed_organisation_id, {})
             json.dump(
                 transform_system(
                     {
                         "system_name": system_data["system_name"],
                         "system_id": system_data["system_id"],
+                        "organisation_id": organisation.get("organisation_id"),
                         "app_version": "webcaf-1",
                     }
                 ),
@@ -385,7 +396,7 @@ def main() -> None:
 
     # Write organisations and systems data
     _write_organisations_data(organisations)
-    _write_systems_data(systems)
+    _write_systems_data(systems, organisations, assessments_metadata)
 
     # Report results
     _report_missing_assessments(missing_assessments)

--- a/webcaf/webcaf/utils/data_migration/review_transformer.py
+++ b/webcaf/webcaf/utils/data_migration/review_transformer.py
@@ -23,7 +23,9 @@ def transform_review_v1_to_v2(
     status_map = {"ACH": "achieved", "PAC": "partially-achieved", "NAC": "not-achieved"}
 
     # Parse old assessment data
-    group_comments, outcomes, supplementary_questions = _parse_old_assessment_data(old_assessment_data)
+    group_comments, group_assessor_comments, outcomes, supplementary_questions = _parse_old_assessment_data(
+        old_assessment_data
+    )
 
     # Process all outcomes
     objectives = definition_structure[version_key].get("objectives", {})
@@ -31,7 +33,9 @@ def transform_review_v1_to_v2(
         objective_entry = review.setdefault(objective_key, {})
         for principle_key, principle in objective.get("principles", {}).items():
             for outcome_key, outcome in principle.get("outcomes", {}).items():
-                outcome_structure = _process_review_outcome(outcome_key, outcome, outcomes, status_map)
+                outcome_structure = _process_review_outcome(
+                    outcome_key, outcome, outcomes, status_map, group_assessor_comments
+                )
                 if outcome_structure:
                     objective_entry[outcome_key] = outcome_structure
     return review
@@ -42,6 +46,7 @@ def _process_review_outcome(
     outcome: dict[str, Any],
     outcomes: dict[str, list],
     status_map: dict[str, str],
+    group_assessor_comments: dict[str, list[str]],
 ) -> dict[str, Any] | None:
     """Process a single outcome and return its assessment structure."""
     outcome_data = outcomes.get(outcome_key, [])
@@ -55,12 +60,18 @@ def _process_review_outcome(
 
     # Process all indicator types
     indicators_dict = {}
-    indicators_dict.update(_process_review_indicators_by_type(achieved_indicators, "achieved", indicator_entries))
     indicators_dict.update(
-        _process_review_indicators_by_type(partially_achieved_indicators, "partially-achieved", indicator_entries)
+        _process_review_indicators_by_type(achieved_indicators, "achieved", indicator_entries, group_assessor_comments)
     )
     indicators_dict.update(
-        _process_review_indicators_by_type(not_achieved_indicators, "not-achieved", indicator_entries)
+        _process_review_indicators_by_type(
+            partially_achieved_indicators, "partially-achieved", indicator_entries, group_assessor_comments
+        )
+    )
+    indicators_dict.update(
+        _process_review_indicators_by_type(
+            not_achieved_indicators, "not-achieved", indicator_entries, group_assessor_comments
+        )
     )
 
     if not outcome_entry:
@@ -81,10 +92,19 @@ def _process_review_outcome(
     }
 
 
+def _get_indicator_comment(entry: dict[str, Any], group_comments: dict[str, list]) -> str:
+    """Extract comment from indicator entry."""
+    g_key: str | None = entry.get("group_key")
+    if g_key and g_key in group_comments:
+        return "\n\n".join(group_comments[g_key])
+    return entry.get("assessor_comment") or ""
+
+
 def _process_review_indicators_by_type(
     indicators: dict[str, Any],
     indicator_type: str,
     indicator_entries: list[dict[str, Any]],
+    group_assessor_comments: dict[str, Any],
 ) -> dict[str, Any]:
     """Process all indicators of a specific type (achieved, partially-achieved, not-achieved)."""
     indicators_dict: dict[str, Any] = {}
@@ -92,7 +112,9 @@ def _process_review_indicators_by_type(
         try:
             entry = next(filter(lambda x: x["key"] == ind_id, indicator_entries))
             indicators_dict[f"{indicator_type}_{ind_id}"] = entry["assessor_answer"] or ""
-            indicators_dict[f"{indicator_type}_{ind_id}_comment"] = entry["assessor_comment"] or ""
+            indicators_dict[f"{indicator_type}_{ind_id}_comment"] = _get_indicator_comment(
+                entry, group_assessor_comments
+            )
         except StopIteration:
             print(f"Indicator is not found: Indicator entry not found for ID: {ind_id}")
     return indicators_dict

--- a/webcaf/webcaf/views/two_factor_auth.py
+++ b/webcaf/webcaf/views/two_factor_auth.py
@@ -97,7 +97,7 @@ class Verify2FATokenView(LoginRequiredMixin, FormView):
                     """,
                 ],
             }
-            logger.error(f"User {request.user.pk} does not have an email associated with the account")
+            logger.warning(f"User {request.user.pk} does not have an email associated with the account")
 
         return self.render_to_response(data)
 


### PR DESCRIPTION
- Converted the hosting_type, system_owner and the last_assessed fields in to a string element from an array. The earlier schema was identified to be incorrect as those fields can only have one value in them.

- Group the assessor comments in the review based on the grouping key. This was not implemented previously.

- Add organisation_id to the system for old webcaf model. Previously it was missed.

- Fixed the review_period element in webcaf-1 export. Having an empty value for webcaf-1 confused Glue schema generation.

- Fixed the priority_recommendation flag calculation. There was a logic issue which did not use the correct value to check whether the profile was met. It was using 'yes' instead on 'met'.

- Updated the tests to confirm the changes