### PR TITLE
Update CAF profile display in review report template

### DIFF
--- a/webcaf/webcaf/templates/review/review-report.html
+++ b/webcaf/webcaf/templates/review/review-report.html
@@ -421,7 +421,7 @@
                                     {% get_tag_for_status review_data.review_data.review_decision|status_to_label as tag_colour %}
                                     <strong class="govuk-tag govuk-tag--{{ tag_colour }}">{{ review_data.review_data.review_decision|status_to_label }}</strong>
                                 </p>
-                                <p class="govuk-heading-s">Baseline CAF profile:
+                                <p class="govuk-heading-s">{{ object_version.assessment.get_caf_profile_display }} CAF profile:
                                     <strong class="govuk-tag govuk-tag--{% if profile_met.0 == 'Yes' %}green{% else %}red{% endif %}">
                                         {% if profile_met.0 == 'Not met' %}Not met{% else %} Met{% endif %}
                                     </strong>


### PR DESCRIPTION
- Replaced static "Baseline CAF profile" text with dynamic value from `object_version.assessment.get_caf_profile_display`.

- This is to confirm that we display the actual profile, selected by the organisation