### PR TITLE
Feature/minor improvements

### DIFF
--- a/tests/admin/test_tip_review_admin.py
+++ b/tests/admin/test_tip_review_admin.py
@@ -1,0 +1,229 @@
+"""
+Tests for the admin changes in ``webcaf/webcaf/admin.py`` covering:
+
+* ``TipAdmin`` history restore gating — only a superuser may restore a Tip from
+  its history; users holding ``can_approve_tip`` / ``can_reject_tip`` can view a
+  Tip but must not be able to restore it, and a restore attempt is refused.
+* ``ReviewAdmin`` "_reopen" handling — posting ``_reopen`` rolls a completed
+  review back to ``in_progress`` and drops the finalise data, and only a
+  superuser is allowed to do so.
+
+These tests exercise the admin classes directly with ``RequestFactory`` (fast,
+deterministic, no reliance on admin templates) and add a couple of end-to-end
+checks against the real history view for the visible "Revert" affordance.
+"""
+import freezegun
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Permission, User
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.test import RequestFactory, TestCase
+
+from webcaf.webcaf.admin import ReviewAdmin, TipAdmin
+from webcaf.webcaf.models import Assessment, Organisation, Review, System, Tip
+
+
+def _reload_user(user: User) -> User:
+    """Re-fetch a user so the per-instance permission cache is rebuilt.
+
+    ``User.has_perm`` memoises the permission set on the instance, so after
+    granting a permission we must reload to see it.
+    """
+    return User.objects.get(pk=user.pk)
+
+
+@freezegun.freeze_time("2025-01-01")
+class TipAdminHistoryRestoreTests(TestCase):
+    """Only superusers may restore a Tip from history (admin.py revert gating)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation = Organisation.objects.create(name="Test Organisation")
+        cls.system = System.objects.create(name="Test System", organisation=cls.organisation)
+        cls.assessment = Assessment.objects.create(
+            system=cls.system,
+            assessment_period="24/25",
+            framework="caf32",
+            caf_profile="baseline",
+            review_type="independent",
+        )
+        cls.review = Review.objects.create(assessment=cls.assessment, status="in_progress")
+        cls.tip = Tip.objects.create(review=cls.review)
+
+        # Superuser: full rights, including history restore.
+        cls.superuser = User.objects.create_superuser(
+            username="admin@test.gov.uk",
+            email="admin@test.gov.uk",
+            password="pw",  # pragma: allowlist secret
+        )
+
+        # Staff user that can approve tips but is NOT a superuser.
+        cls.approver = User.objects.create_user(
+            username="approver@test.gov.uk", email="approver@test.gov.uk", is_staff=True
+        )
+        cls.approver.user_permissions.add(Permission.objects.get(codename="can_approve_tip"))
+        cls.approver = _reload_user(cls.approver)
+
+        # Staff user that can reject tips but is NOT a superuser.
+        cls.rejecter = User.objects.create_user(
+            username="rejecter@test.gov.uk", email="rejecter@test.gov.uk", is_staff=True
+        )
+        cls.rejecter.user_permissions.add(Permission.objects.get(codename="can_reject_tip"))
+        cls.rejecter = _reload_user(cls.rejecter)
+
+        # Plain staff user with neither permission.
+        cls.plain_staff = User.objects.create_user(
+            username="staff@test.gov.uk", email="staff@test.gov.uk", is_staff=True
+        )
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.admin = TipAdmin(Tip, AdminSite())
+
+    def _request(self, user, method="get", data=None):
+        request = getattr(self.factory, method)("/", data or {})
+        request.user = user
+        return request
+
+    # --- revert_disabled: the switch that hides the "Revert" button --------
+
+    def test_superuser_can_restore_history(self):
+        """A superuser has revert enabled (revert_disabled is False)."""
+        request = self._request(self.superuser)
+        self.assertFalse(self.admin.revert_disabled(request, self.tip))
+
+    def test_approver_cannot_restore_history(self):
+        """A can_approve_tip user has revert disabled."""
+        request = self._request(self.approver)
+        self.assertTrue(self.admin.revert_disabled(request, self.tip))
+
+    def test_rejecter_cannot_restore_history(self):
+        """A can_reject_tip user has revert disabled."""
+        request = self._request(self.rejecter)
+        self.assertTrue(self.admin.revert_disabled(request, self.tip))
+
+    def test_plain_staff_cannot_restore_history(self):
+        """A non-superuser without approve/reject perms has revert disabled."""
+        request = self._request(self.plain_staff)
+        self.assertTrue(self.admin.revert_disabled(request, self.tip))
+
+    # --- has_change_history_permission mirrors revert_disabled -------------
+
+    def test_has_change_history_permission_follows_revert_disabled(self):
+        """``has_change_history_permission`` delegates to ``revert_disabled``."""
+        for user in (self.superuser, self.approver, self.rejecter, self.plain_staff):
+            with self.subTest(user=user.username):
+                request = self._request(user)
+                self.assertEqual(
+                    self.admin.has_change_history_permission(request, self.tip),
+                    self.admin.revert_disabled(request, self.tip),
+                )
+
+    # --- the "permission error" a restore POST would hit ------------------
+
+    def test_approver_restore_post_is_denied_by_change_permission(self):
+        """
+        A history restore is a change POST without ``_approve``/``_reject``.
+        For an approve/reject user that POST is refused by
+        ``has_change_permission`` — the permission error described in the spec.
+        """
+        for user in (self.approver, self.rejecter):
+            with self.subTest(user=user.username):
+                post = self._request(user, method="post", data={"_save": "Revert"})
+                self.assertFalse(self.admin.has_change_permission(post, self.tip))
+
+    def test_approver_may_still_view_tip(self):
+        """The approve/reject users retain view access to the Tip admin."""
+        for user in (self.approver, self.rejecter):
+            with self.subTest(user=user.username):
+                request = self._request(user)
+                self.assertTrue(self.admin.has_view_permission(request, self.tip))
+
+    def test_superuser_restore_post_is_allowed(self):
+        """A superuser is not blocked from a restore/change POST."""
+        post = self._request(self.superuser, method="post", data={"_save": "Revert"})
+        self.assertTrue(self.admin.has_change_permission(post, self.tip))
+
+
+@freezegun.freeze_time("2025-01-01")
+class ReviewAdminReopenTests(TestCase):
+    """``ReviewAdmin.save_model`` "_reopen" rollback behaviour (admin.py)."""
+
+    assessment: Assessment
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation = Organisation.objects.create(name="Reopen Organisation")
+        cls.system = System.objects.create(name="Reopen System", organisation=cls.organisation)
+        cls.assessment = Assessment.objects.create(
+            system=cls.system,
+            assessment_period="24/25",
+            framework="caf32",
+            caf_profile="baseline",
+            review_type="independent",
+        )
+        cls.superuser = User.objects.create_superuser(
+            username="reopen-admin@test.gov.uk",
+            email="reopen-admin@test.gov.uk",
+            password="pw",  # pragma: allowlist secret
+        )
+        cls.staff = User.objects.create_user(
+            username="reopen-staff@test.gov.uk", email="reopen-staff@test.gov.uk", is_staff=True
+        )
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.admin = ReviewAdmin(Review, AdminSite())
+
+    def _completed_finalised_review(self) -> Review:
+        """Create a review that is completed and finalised.
+
+        Creating with ``status="completed"`` on a fresh instance is allowed —
+        the model's "cannot change after completed" guard only fires on update.
+        """
+        return Review.objects.create(
+            assessment=self.assessment,
+            status="completed",
+            review_data={
+                "review_completion": {"review_completed": "yes", "review_completed_at": "2026-01-01T00:00:00"},
+                "review_finalised": {"review_finalised_by": "Someone"},
+                "assessor_response_data": {"A": {}},
+            },
+        )
+
+    def _post(self, user, data):
+        request = self.factory.post("/admin/webcaf/review/1/change/", data)
+        request.user = user
+        return request
+
+    def test_superuser_reopen_rolls_back_to_in_progress(self):
+        """Posting ``_reopen`` as a superuser reopens the review and drops finalise data."""
+        review = self._completed_finalised_review()
+        request = self._post(self.superuser, {"_reopen": "Reopen"})
+
+        self.admin.save_model(request, review, form=None, change=True)
+
+        review.refresh_from_db()
+        self.assertEqual(review.status, "in_progress")
+        self.assertNotIn("review_finalised", review.review_data)
+        self.assertNotIn("review_completion", review.review_data)
+        # Assessor answers are preserved — only the finalise/completion markers go.
+        self.assertIn("assessor_response_data", review.review_data)
+        self.assertEqual(review.last_updated_by, self.superuser)
+
+    def test_non_superuser_reopen_raises_permission_denied(self):
+        """A non-superuser posting ``_reopen`` is refused and the review is untouched."""
+        review = self._completed_finalised_review()
+        request = self._post(self.staff, {"_reopen": "Reopen"})
+
+        with self.assertRaises(PermissionDenied):
+            self.admin.save_model(request, review, form=None, change=True)
+
+        review.refresh_from_db()
+        self.assertEqual(review.status, "completed")
+        self.assertIn("review_finalised", review.review_data)
+
+    def test_rollback_requires_completed_status(self):
+        """The model guard rejects reopening a review that is not completed."""
+        review = Review.objects.create(assessment=self.assessment, status="in_progress")
+        with self.assertRaises(ValidationError):
+            review.rollback_to_in_progress()

--- a/tests/test_models/test_review.py
+++ b/tests/test_models/test_review.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 
 from tests.test_views.base_view_test import BaseViewTest
 from webcaf.webcaf.models import Assessment, Review
@@ -956,7 +957,7 @@ class ReviewCompletionInfoTests(BaseViewTest):
         """Test that completion_info handles datetime objects that are already parsed."""
         from datetime import datetime
 
-        dt = datetime(2024, 12, 1, 10, 30, 45)
+        dt = timezone.make_aware(datetime(2024, 12, 1, 10, 30, 45))
         review = Review.objects.create(
             assessment=self.assessment,
             status="completed",

--- a/webcaf/settings.py
+++ b/webcaf/settings.py
@@ -256,6 +256,12 @@ LOGGING = {
             "handlers": ["console"],
             "propagate": True,
         },
+        # Get SQL query logs in development
+        "django.db.backends": {
+            "handlers": ["console"],
+            "level": ("WARN" if not DEBUG else "DEBUG"),
+            "propagate": False,
+        },
     },
 }
 

--- a/webcaf/webcaf/admin.py
+++ b/webcaf/webcaf/admin.py
@@ -4,12 +4,13 @@ import logging
 import zoneinfo
 from datetime import datetime
 from io import BytesIO, StringIO, TextIOWrapper
-from typing import Any, Optional
+from typing import Any, MutableMapping, Optional
 from zoneinfo import ZoneInfo
 
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth.models import User
+from django.core.exceptions import PermissionDenied
 from django.core.validators import RegexValidator
 from django.db.models import F, Model, Q
 from django.forms import CharField, DateTimeInput, ModelForm
@@ -33,6 +34,77 @@ from webcaf.webcaf.models import (
 )
 from webcaf.webcaf.tip.util import RecommendationService
 from webcaf.webcaf.views.system import SystemForm
+
+
+class PrettyJSONWidget(forms.Textarea):
+    """
+    A custom widget that extends the Django Textarea widget for formatting JSON data.
+
+    This widget ensures that JSON data is presented in a readable, pretty-printed format
+    with an indentation of 4 spaces. It supports JSON input in string format and attempts
+    to parse and reformat it. If parsing fails, the raw value is returned.
+
+    :ivar is_required: Indicates whether the widget is required in forms.
+    :type is_required: bool
+    """
+
+    def format_value(self, value):
+        if value in ("", None):
+            return ""
+        try:
+            if isinstance(value, str):
+                value = json.loads(value)
+            return json.dumps(value, indent=4)
+        except Exception:
+            return value
+
+
+class JsonDataAdminForm(forms.ModelForm):
+    """
+    Base ``ModelForm`` for admin models that expose a single large JSON field.
+
+    Subclasses only need to declare :attr:`json_field` (and the usual ``Meta``
+    naming their model). The base class provides the behaviour shared by all
+    such forms:
+
+    * renders the JSON field with :class:`PrettyJSONWidget` for readable,
+      pretty-printed output;
+    * seeds the form's initial data from the current instance so the stored
+      JSON is shown on load;
+    * parses a submitted JSON string back into a Python object on clean.
+
+    :cvar json_field: Name of the model field holding the JSON payload.
+    :cvar json_readonly: Whether the JSON widget should be rendered read-only.
+        A read-only flag applied elsewhere (e.g. per-request in an admin's
+        ``get_form``) is also honoured.
+    """
+
+    json_field: str = ""
+    json_readonly: bool = False
+    # Get around mypy warning
+    initial: MutableMapping[str, Any]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        field = self.fields[self.json_field]
+        # Honour a read-only flag set either on the class or on the widget by
+        # the admin's ``get_form`` before swapping in the pretty widget.
+        attrs = {"rows": 20, "cols": 60}
+        if self.json_readonly or field.widget.attrs.get("readonly"):
+            attrs["readonly"] = True
+        field.widget = PrettyJSONWidget(attrs=attrs)
+
+        value = getattr(self.instance, self.json_field, None)
+        if value:
+            self.initial[self.json_field] = value
+
+    def clean(self) -> dict[str, Any]:
+        cleaned_data = super().clean()
+        if cleaned_data:
+            value = cleaned_data.get(self.json_field)
+            if isinstance(value, str):
+                cleaned_data[self.json_field] = json.loads(value)
+        return cleaned_data if cleaned_data else {}
 
 
 class OptionalFieldsAdminMixin:
@@ -388,9 +460,19 @@ class SystemAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):  # type: ignore
         js = ("webcaf/js/admin_system.js",)
 
 
+class AssessmentAdminForm(JsonDataAdminForm):
+    json_field = "assessments_data"
+    json_readonly = True
+
+    class Meta:
+        model = Assessment
+        fields = "__all__"
+
+
 @admin.register(Assessment)
 class AssessmentAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):  # type: ignore
     model = Assessment
+    form = AssessmentAdminForm
     search_fields = ["status", "system__name", "reference"]
     list_display = [
         "status",
@@ -537,8 +619,18 @@ class ConfigurationAdmin(admin.ModelAdmin):
     form = CustomConfigForm
 
 
+class ReviewAdminForm(JsonDataAdminForm):
+    json_field = "review_data"
+    json_readonly = True
+
+    class Meta:
+        model = Review
+        fields = "__all__"
+
+
 @admin.register(Review)
 class ReviewAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):
+    form = ReviewAdminForm
     search_fields = ["assessment_system_name", "assessment_reference", "assessment_organisation"]
     list_display = [
         "assessment_system_name",
@@ -624,10 +716,8 @@ class ReviewAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "assessment":
-            current_config = Configuration.objects.get_default_config()
             kwargs["queryset"] = Assessment.objects.filter(
                 status="submitted",
-                assessment_period=current_config.get_current_assessment_period(),
             ).order_by("-created_on")
         form_field = super().formfield_for_foreignkey(db_field, request, **kwargs)
         return form_field
@@ -635,48 +725,27 @@ class ReviewAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):
     def save_form(self, request, form, change):
         return super().save_form(request, form, change)
 
-    def save_model(self, request, obj, form, change):
-        if hasattr(obj, "last_updated_by"):
-            obj.last_updated_by = request.user
+    def save_model(self, request, obj: Review, form, change):
+        obj.last_updated_by = request.user
+        if "_reopen" in request.POST:
+            if request.user.is_superuser:
+                obj.rollback_to_in_progress()
+            else:
+                raise PermissionDenied("Only admins can reopen reports")
         super().save_model(request, obj, form, change)
 
-
-class PrettyJSONWidget(forms.Textarea):
-    def format_value(self, value):
-        if value in ("", None):
-            return ""
-        try:
-            if isinstance(value, str):
-                value = json.loads(value)
-            return json.dumps(value, indent=4)
-        except Exception:
-            return value
+    class Media:
+        css = {"all": ("webcaf/admin.css",)}
 
 
-class TipAdminForm(forms.ModelForm):
+class TipAdminForm(JsonDataAdminForm):
+    json_field = "tip_data"
+
+    # Read-only state is decided per-request in ``TipAdmin.get_form``.
+
     class Meta:
         model = Tip
         fields = "__all__"
-        widgets = {
-            "tip_data": PrettyJSONWidget(
-                attrs={
-                    "rows": 20,
-                    "cols": 60,
-                    # "style": "font-family: monospace; width: 100%;"
-                }
-            )
-        }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.instance and self.instance.tip_data:
-            self.initial["tip_data"] = self.instance.tip_data
-
-    def clean_tip_data(self):
-        value = self.cleaned_data["tip_data"]
-        if isinstance(value, str):
-            return json.loads(value)
-        return value
 
 
 @admin.register(Tip)
@@ -790,6 +859,8 @@ class TipAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):
             assessment_review_type=F("review__assessment__review_type"),
             assessment_reference=F("review__assessment__reference"),
             assessment_organisation=F("review__assessment__system__organisation__name"),
+        ).select_related(
+            "review", "review__assessment", "review__assessment__system", "review__assessment__system__organisation"
         )
 
     def get_urls(self):
@@ -919,6 +990,25 @@ class TipAdmin(OptionalFieldsAdminMixin, SimpleHistoryAdmin):
                 return True
             return request.user.is_superuser or "_approve" in request.POST or "_reject" in request.POST
         return super().has_change_permission(request, obj)
+
+    def revert_disabled(self, request, obj=None):
+        """
+        Determines whether a user has permission to view the history of an object.
+
+        This function checks if the user associated with the provided request is a
+        superuser and grants or denies access accordingly.
+
+        :param request: The HTTP request object containing user information.
+        :type request: HttpRequest
+        :param obj: (Optional) The object to check view history permission for. Defaults to None.
+        :type obj: Any
+        :return: True if the user is a superuser, otherwise False.
+        :rtype: bool
+        """
+        return not request.user.is_superuser
+
+    def has_change_history_permission(self, request, obj=None):
+        return self.revert_disabled(request, obj)
 
     class Media:
         css = {"all": ("webcaf/admin.css",)}

--- a/webcaf/webcaf/models.py
+++ b/webcaf/webcaf/models.py
@@ -1079,7 +1079,9 @@ class Review(ReferenceGeneratorMixin, models.Model):
         if review_completion is not None:
             if completed_at := review_completion.get("review_completed_at"):
                 if type(completed_at) is str:
-                    review_completion["review_completed_at"] = datetime.strptime(completed_at, "%Y-%m-%dT%H:%M:%S.%f")
+                    review_completion["review_completed_at"] = django_utils_timezone.make_aware(
+                        datetime.strptime(completed_at, "%Y-%m-%dT%H:%M:%S.%f")
+                    )
         return review_completion
 
     def reopen(self):
@@ -1099,10 +1101,8 @@ class Review(ReferenceGeneratorMixin, models.Model):
         if self.status != "completed" or self.is_review_finalised():
             raise ValidationError("Invalid state for report reopening.")
 
-        review_completion = _get_or_create_nested_path(self.review_data, "review_completion")
+        self.review_data.pop("review_completion", None)
         self.status = "in_progress"
-        # Remove the review_completed key and its associated values
-        review_completion.clear()
 
     @transaction.atomic
     def finalise_review(self, profile: UserProfile):

--- a/webcaf/webcaf/templates/admin/webcaf/review/submit_line.html
+++ b/webcaf/webcaf/templates/admin/webcaf/review/submit_line.html
@@ -1,0 +1,10 @@
+{% extends "admin/submit_line.html" %}
+{% block submit-row %}
+    {% if user.is_superuser %}
+        {% if original.is_review_finalised %}
+            <input type="submit" value="Un Finalise" name="_reopen" class="button-reject" title="Only admins can reopen reports,
+            This will put the review in to a state that can be reopened in the frontend.">
+        {% endif %}
+        {{ block.super }}
+    {% endif %}
+{% endblock %}

--- a/webcaf/webcaf/templates/review/revisions.html
+++ b/webcaf/webcaf/templates/review/revisions.html
@@ -1,4 +1,5 @@
 {% extends "review-base.html" %}
+{% load tz %}
 {% load review_tags %}
 {% load form_extras %}
 {% load permission_extras %}
@@ -96,8 +97,10 @@
                         <td class="govuk-table__cell">Version {{ forloop.revcounter }}</td>
                         <td class="govuk-table__cell">
                             {% if revision.instance.completion_info %}
-                                {{ revision.instance.completion_info.review_completed_at|date:"d F Y" }}
-                                at {{ revision.instance.completion_info.review_completed_at|date:"H:i" }}
+                                {% timezone "Europe/London" %}
+                                    {{ revision.instance.completion_info.review_completed_at|date:"d F Y" }}
+                                    at {{ revision.instance.completion_info.review_completed_at|date:"H:i" }}
+                                {% endtimezone %}
                             {% else %}
                                 -
                             {% endif %}


### PR DESCRIPTION
[Add SQL query logging](https://github.com/co-cddo/domains-webcaf/commit/3f8d2c11d4cf84435c9c01465bbb5170e96fff19)

- Enabled SQL query logging in dev mode.
This is helpful in identifying N+1 query generation

[Add review rollback button to admin screen](https://github.com/co-cddo/domains-webcaf/commit/d4d9510fff0bd15db7a913c21c557349063016c7)

- Added button to enable review rollback from finalised.
There were some incidents we had to manipulate the json
manually, enabling this button will automate the rollback

- Using the correct timezone information in the review
revisions, earlier it was always displaying in UTC

- Fix N+1 Query issue when loading TIPs in the admin screen.

- Make the json data fields read only for Assessment, Review and Tip.
This is to prevent any accidental modifications to the data.

- Prevent the restore history functionality from the Tip approver users